### PR TITLE
BUG: Fix typo

### DIFF
--- a/CochleaSeg/CochleaSeg.py
+++ b/CochleaSeg/CochleaSeg.py
@@ -747,7 +747,7 @@ class CochleaSegLogic(ScriptedLoadableModuleLogic):
         nimgMax = tmpImgArray.max()
         nimgMin = tmpImgArray.min()
 
-        b= list(zip( *np.where(tmpImgArray > (nimgMax/2) ) ) ))
+        b= list(zip( *np.where(tmpImgArray > (nimgMax/2) )))
         NoPts = len(b)
         ptsIJK   =np.zeros((NoPts,4))
         ptsIJKtmp=np.zeros((NoPts,4))


### PR DESCRIPTION
@idhamari This fixes a minor typo causing some [tests](http://slicer.cdash.org/testDetails.php?test=9646332&build=1609369) to fail.