### PR TITLE
BUG: Fix checksum format

### DIFF
--- a/CochleaSeg/CochleaSeg.py
+++ b/CochleaSeg/CochleaSeg.py
@@ -450,7 +450,7 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
              uris = urisGitHub          
              fileNames    = 'P100001_DV_L_b.nrrd'
              nodeNames    = 'P100001_DV_L_b'
-             checksums    = '9a5722679caa978b1a566f4a148c8759ce38158ca75813925a2d4f964fdeebf5'
+             checksums    = 'SHA256:9a5722679caa978b1a566f4a148c8759ce38158ca75813925a2d4f964fdeebf5'
          elif(cochleaSide=="L" and beforORafter=="_a"  ):
              cochleaPoint = [214,242,78]
              urisUniKo         = "https://cloud.uni-koblenz-landau.de/s/EwQiQidXqTcGySB/download"
@@ -458,7 +458,7 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
              uris = urisGitHub          
              fileNames    = 'P100001_DV_L_a.nrrd'
              nodeNames    = 'P100001_DV_L_a'
-             checksums    = 'd7cda4e106294a59591f03e74fbe9ecffa322dd1a9010b4d0590b377acc05eb5'
+             checksums    = 'SHA256:d7cda4e106294a59591f03e74fbe9ecffa322dd1a9010b4d0590b377acc05eb5'
          elif(cochleaSide=="R" and beforORafter=="_b" ):
              cochleaPoint = [194,216,93]
              urisUniKo   = "https://cloud.uni-koblenz-landau.de/s/4K5gAwisgqSHK4j/download"
@@ -466,7 +466,7 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
              uris = urisGitHub          
              fileNames    = 'P100003_DV_R_b.nrrd' 
              nodeNames    = 'P100003_DV_R_b'
-             checksums    = '4478778377982b6789ddf8f5ccd20f66757d6733853cce3f89faf75df2fa4faa'
+             checksums    = 'SHA256:4478778377982b6789ddf8f5ccd20f66757d6733853cce3f89faf75df2fa4faa'
          elif(cochleaSide=="R" and beforORafter=="_a" ):
              cochleaPoint = [294,250,60]
              urisUniKo    = "https://cloud.uni-koblenz-landau.de/s/WAxHyqLC3JsKY2x/download"
@@ -474,7 +474,7 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
              uris = urisGitHub          
              fileNames    = 'P100003_DV_R_a.nrrd'
              nodeNames    = 'P100003_DV_R_a'
-             checksums    = 'c62d37e13596eafc8550f488006995d811c8d6503445d5324810248a3c3b6f89'
+             checksums    = 'SHA256:c62d37e13596eafc8550f488006995d811c8d6503445d5324810248a3c3b6f89'
          else:
              print("error in cochlea side or before after type")
              return -1


### PR DESCRIPTION
See [failing test](http://slicer.cdash.org/testDetails.php?test=9665176&build=1621477).

This is because of a problem with code introduced in https://github.com/MedicalImageAnalysisTutorials/SlicerCochlea/commit/b50284d1a1cb552a7ee38902ded33fd9e5977c6b.

I also noticed you added checksum code into your 4.10 branch fadc01a89917ba1a038c5e4dfe6974758918264b, but Slicer 4.10.2 doesn't have checksum code in the SampleData module. This was added only for Slicer preview https://github.com/Slicer/Slicer/commit/aedb7d6702a30b485be952f2c933dfd96f072f02. This will need to be fixed.