### PR TITLE
STYLE: Trim trailing whitespace

### DIFF
--- a/CochleaReg/CochleaReg.py
+++ b/CochleaReg/CochleaReg.py
@@ -1,15 +1,15 @@
 #======================================================================================
-#  3D Slicer [1] plugin that uses elastix toolbox [2] Plugin for Automatic Cochlea    # 
+#  3D Slicer [1] plugin that uses elastix toolbox [2] Plugin for Automatic Cochlea    #
 #  Image Registration (ACIR) [3]. More info can be found at [4]                       #
 #  Sample cochlea datasets can be downloaded using Slicer Datastore module            #
 #                                                                                     #
-#  Contributers:                                                                      #   
+#  Contributers:                                                                      #
 #      - Christopher L. Guy,   guycl@vcu.edu              : Original source code.     #
 #      - Ibraheem Al-Dhamari,  idhamari@uni-koblenz.de    : Plugin design.            #
 #      - Michel Peltriaux,     mpeltriaux@uni-koblenz.de  : Programming & testing.    #
 #      - Anna Gessler,         agessler@uni-koblenz.de    : Programming & testing.    #
 #      - Jasper Grimmig        jgrimmig@uni-koblenz.de    : Programming & testing.    #
-#      - Pepe Eulzer           eulzer@uni-koblenz.de      : Programming & testing.    #  
+#      - Pepe Eulzer           eulzer@uni-koblenz.de      : Programming & testing.    #
 #  [1] https://www.slicer.org                                                         #
 #  [2] http://elastix.isi.uu.nl                                                       #
 #  [3] Al-Dhamari et al., (2017): ACIR: automatic cochlea image registration.         #
@@ -19,23 +19,23 @@
 #                                                                                     #
 #-------------------------------------------------------------------------------------#
 #  Slicer 4.11.0                                                                      #
-#  Updated: 24.6.2019                                                                 # 
+#  Updated: 24.6.2019                                                                 #
 #======================================================================================
 
 import os, time, logging, unittest
 import numpy as np
 from __main__ import qt, ctk, slicer
-from slicer.ScriptedLoadableModule import *   
+from slicer.ScriptedLoadableModule import *
 import SampleData
 
 import VisSimCommon
 
-# TODO: 
-# - Visualizing the interimediate steps. 
+# TODO:
+# - Visualizing the interimediate steps.
 
 
 # Terminology
-#  img         : ITK image 
+#  img         : ITK image
 #  imgNode     : Slicer Node
 #  imgName     :  Filename without the path and without extension
 #  imgPath     : wholePath + Filename and extension
@@ -56,9 +56,9 @@ class CochleaReg(ScriptedLoadableModule):
                                "Michel Peltriauxe",
                                "Anna Gessler",
                                "Jasper Grimmig",
-                               "Pepe Eulzer"  
+                               "Pepe Eulzer"
          ]
-        parent.helpText            = " This module uses ACIR method to auatomatically register cochlea images" 
+        parent.helpText            = " This module uses ACIR method to auatomatically register cochlea images"
         parent.acknowledgementText = " This work is sponsored by Cochlear as part of COMBS project "
         self.parent = parent
   #end def init
@@ -70,23 +70,23 @@ class CochleaReg(ScriptedLoadableModule):
 class CochleaRegWidget(ScriptedLoadableModuleWidget):
   def setup(self):
     print(" ")
-    print("=======================================================")   
+    print("=======================================================")
     print("   Automatic Cochlea Image Registration                ")
-    print("=======================================================")    
+    print("=======================================================")
 
     ScriptedLoadableModuleWidget.setup(self)
-      
+
     # to access logic class functions and setup global variables
     self.logic = CochleaRegLogic()
-  
-    # Set default VisSIm location in the user home 
-    #TODO: add option user-defined path when installed first time 
-    self.vsc   = VisSimCommon.VisSimCommonLogic()   
+
+    # Set default VisSIm location in the user home
+    #TODO: add option user-defined path when installed first time
+    self.vsc   = VisSimCommon.VisSimCommonLogic()
     self.vsc.setGlobalVariables(0)
 
-    #----------------------------------------------------------------- 
+    #-----------------------------------------------------------------
     #                     Create the GUI interface
-    #----------------------------------------------------------------- 
+    #-----------------------------------------------------------------
     # Create collapsible Button for registration, transformix and invert transform
     self.mainCollapsibleBtn = ctk.ctkCollapsibleButton()
     self.mainCollapsibleBtn.setStyleSheet("ctkCollapsibleButton { background-color: DarkSeaGreen  }")
@@ -118,13 +118,13 @@ class CochleaRegWidget(ScriptedLoadableModuleWidget):
     self.movingSelectorCoBx.showChildNodeTypes     = False
     self.movingSelectorCoBx.setMRMLScene( slicer.mrmlScene )
     self.movingSelectorCoBx.setToolTip("Pick the moving volume")
-    self.mainFormLayout.addRow("Moving Volume: ", self.movingSelectorCoBx)       
+    self.mainFormLayout.addRow("Moving Volume: ", self.movingSelectorCoBx)
 
     # Create a time label
     self.timeLbl = qt.QLabel("                 Time: 00:00")
-    self.timeLbl.setFixedWidth(500)   
+    self.timeLbl.setFixedWidth(500)
     self.tmLbl = self.timeLbl
-    
+
     # Create a textbox for cochlea location
     # TODO activate input IJK values as well
     self.fixedPointEdt = qt.QLineEdit()
@@ -142,15 +142,15 @@ class CochleaRegWidget(ScriptedLoadableModuleWidget):
     self.fixedFiducialBtn.setFixedHeight(40)
     self.fixedFiducialBtn.setToolTip("Pick the fixed fiducial point that will be the center of the cropped image")
     self.fixedFiducialBtn.connect('clicked(bool)', lambda: self.onInputFiducialBtnClick("F"))
-    self.mainFormLayout.addRow( self.fixedFiducialBtn, self.fixedPointEdt)    
+    self.mainFormLayout.addRow( self.fixedFiducialBtn, self.fixedPointEdt)
 
     # Create a cochlea locator button
     self.movingFiducialBtn = qt.QPushButton("Pick cochlea location in moving image    ")
     self.movingFiducialBtn.setFixedHeight(40)
     self.movingFiducialBtn.setToolTip("Pick the moving fiducial point that will be the center of the cropped image")
     self.movingFiducialBtn.connect('clicked(bool)', lambda: self.onInputFiducialBtnClick("M"))
-    self.mainFormLayout.addRow( self.movingFiducialBtn, self.movingPointEdt)    
-        
+    self.mainFormLayout.addRow( self.movingFiducialBtn, self.movingPointEdt)
+
     # Add check box for disabling colors in the result of the registration
     self.colorsChkBox = qt.QCheckBox()
     self.colorsChkBox.text = "Disable colors"
@@ -167,7 +167,7 @@ class CochleaRegWidget(ScriptedLoadableModuleWidget):
     self.applyBtn.connect('clicked(bool)', self.onApplyBtnClick)
     self.mainFormLayout.addRow(self.applyBtn, self.timeLbl)
     self.runBtn = self.applyBtn
-    
+
     self.layout.addStretch(1) # Collapsible button is held in place when collapsing/expanding.
 
   #------------------------------------------------------------------------
@@ -176,39 +176,39 @@ class CochleaRegWidget(ScriptedLoadableModuleWidget):
   def onInputFiducialBtnClick(self, volumeType):
       if not hasattr(self.vsc, 'vtVars'):
          self.vsc.setGlobalVariables(0)
-       #end 
+       #end
       self.fixedVolumeNode=self.fixedSelectorCoBx.currentNode()
       self.movingVolumeNode=self.movingSelectorCoBx.currentNode()
-      self.logic.fixedFiducialNode = None    
-      self.logic.movingFiducialNode = None    
+      self.logic.fixedFiducialNode = None
+      self.logic.movingFiducialNode = None
       #remove old nodes
       nodes = slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode')
       for f in nodes:
           if (f.GetName() == "_CochleaLocation") :
-               slicer.mrmlScene.RemoveNode(f) 
+               slicer.mrmlScene.RemoveNode(f)
           #endif
-      #endfor    
+      #endfor
       # Create Fiducial Node for the cochlea location in both images
       if (volumeType=="F"):
-         print(" ..... getting cochlea location in the fixed image")  
-         self.fixedFiducialBtn.setStyleSheet("QPushButton{ background-color: White  }")   
-         self.vsc.locateItem(self.fixedSelectorCoBx.currentNode(), self.fixedPointEdt,1, 0)    
+         print(" ..... getting cochlea location in the fixed image")
+         self.fixedFiducialBtn.setStyleSheet("QPushButton{ background-color: White  }")
+         self.vsc.locateItem(self.fixedSelectorCoBx.currentNode(), self.fixedPointEdt,1, 0)
          self.fixedFiducialNode= self.vsc.inputFiducialNodes[1]
          self.fixedFiducialBtn.setStyleSheet("QPushButton{ background-color: DarkSeaGreen  }")
-      elif (volumeType=="M"):              
-         print(" ..... getting cochlea location in the fixed image")  
-         self.vsc.locateItem(self.movingSelectorCoBx.currentNode(), self.movingPointEdt,2, 0)    
+      elif (volumeType=="M"):
+         print(" ..... getting cochlea location in the fixed image")
+         self.vsc.locateItem(self.movingSelectorCoBx.currentNode(), self.movingPointEdt,2, 0)
          self.movingFiducialNode= self.vsc.inputFiducialNodes[2]
          self.movingFiducialBtn.setStyleSheet("QPushButton{ background-color: DarkSeaGreen  }")
-    #endif    
-  #enddef      
-       
+    #endif
+  #enddef
+
 
   # An option to control results displaying
   def OnColorsChkBoxChange(self):
-        print("color is changed") 
+        print("color is changed")
         self.vsc.fuseWithOutColor(self.colorsChkBox.checked)
-                        
+
   def onApplyBtnClick(self):
       self.runBtn.setText("...please wait")
       self.runBtn.setStyleSheet("QPushButton{ background-color: red  }")
@@ -216,7 +216,7 @@ class CochleaRegWidget(ScriptedLoadableModuleWidget):
       self.stm=time.time()
       print("time:" + str(self.stm))
       self.timeLbl.setText("                 Time: 00:00")
-    
+
       print(type(self.fixedFiducialNode))
       # create an option to use IJK point or fidicual node
       registeredMovingVolumeNode =self.logic.run( self.fixedSelectorCoBx.currentNode(),self.fixedFiducialNode, self.movingSelectorCoBx.currentNode(),self.movingFiducialNode )
@@ -228,17 +228,17 @@ class CochleaRegWidget(ScriptedLoadableModuleWidget):
       self.runBtn.setStyleSheet("QPushButton{ background-color: DarkSeaGreen  }")
       slicer.app.processEvents()
   #enddef
-  
-  def cleanup(self):  
+
+  def cleanup(self):
       pass
   #enddef
-  
+
 #===================================================================
 #                           Logic
 #===================================================================
 class CochleaRegLogic(ScriptedLoadableModuleLogic):
-  #--------------------------------------------------------------------------------------------  
-  #                       Registration Process 
+  #--------------------------------------------------------------------------------------------
+  #                       Registration Process
   #--------------------------------------------------------------------------------------------
   # This method perform the registration steps
   def run(self, fixedVolumeNode, fixedFiducialNode, movingVolumeNode, movingFiducialNode):
@@ -250,7 +250,7 @@ class CochleaRegLogic(ScriptedLoadableModuleLogic):
 
       self.vsc.removeOtputsFolderContents()
 
-      # results paths        
+      # results paths
       resTransPath  = os.path.join(self.vsc.vtVars['outputPath'] ,"TransformParameters.0.txt")
       resOldDefPath = os.path.join(self.vsc.vtVars['outputPath'] , "deformationField"+self.vsc.vtVars['imgType'])
       resDefPath    = os.path.join(self.vsc.vtVars['outputPath'] , movingVolumeNode.GetName()+"_dFld"+self.vsc.vtVars['imgType'])
@@ -267,7 +267,7 @@ class CochleaRegLogic(ScriptedLoadableModuleLogic):
           slicer.util.saveNode(movingVolumeNode, movingImgPath)
       movingPath = movingVolumeNode.GetStorageNode().GetFileName()
 
-      # Get IJK point from the fiducial to use in cropping          
+      # Get IJK point from the fiducial to use in cropping
       fixedPoint = self.vsc.ptRAS2IJK(fixedFiducialNode,fixedVolumeNode,0)
       print("run fixed point: ============================")
       print(fixedVolumeNode.GetName())
@@ -276,9 +276,9 @@ class CochleaRegLogic(ScriptedLoadableModuleLogic):
       if  np.sum(fixedPoint)== 0 :
             print("Error: select cochlea fixed point")
             return -1
-      #endif  
-      fnm = os.path.join(self.vsc.vtVars['outputPath'] , fixedVolumeNode.GetName()+"_F_Cochlea_Pos.fcsv")                           
-      sR = slicer.util.saveNode(fixedFiducialNode, fnm )  
+      #endif
+      fnm = os.path.join(self.vsc.vtVars['outputPath'] , fixedVolumeNode.GetName()+"_F_Cochlea_Pos.fcsv")
+      sR = slicer.util.saveNode(fixedFiducialNode, fnm )
 
       movingPoint = self.vsc.ptRAS2IJK(movingFiducialNode,movingVolumeNode,0)
       print("run moving point: ============================")
@@ -289,54 +289,54 @@ class CochleaRegLogic(ScriptedLoadableModuleLogic):
       if  np.sum(fixedPoint)== 0 :
             print("Error: select cochlea moving point")
             return -1
-      #endif  
-      fnm = os.path.join(self.vsc.vtVars['outputPath'] , movingVolumeNode.GetName()+"_M_Cochlea_Pos.fcsv")                           
-      sR = slicer.util.saveNode(movingFiducialNode, fnm )  
+      #endif
+      fnm = os.path.join(self.vsc.vtVars['outputPath'] , movingVolumeNode.GetName()+"_M_Cochlea_Pos.fcsv")
+      sR = slicer.util.saveNode(movingFiducialNode, fnm )
 
       #Remove old resulted nodes
       #for node in slicer.util.getNodes():
       #    if ( "result"   in [node].GetName() ): slicer.mrmlScene.RemoveNode(node) #endif
-      #endfor    
-  
+      #endfor
+
       # TODO: add better condition
       if  (np.sum(fixedPoint)== 0) and (np.sum(movingPoint)== 0) :
             #qt.QMessageBox.critical(slicer.util.mainWindow(),'SlicerCochleaRegistration', 'Cochlea locations are missing')
             print("Error: select cochlea points in fixed and moving images")
             return False
-      #endif  
+      #endif
 
-      fixedPointT = self.vsc.v2t(fixedPoint) 
-      movingPointT = self.vsc.v2t(movingPoint) 
+      fixedPointT = self.vsc.v2t(fixedPoint)
+      movingPointT = self.vsc.v2t(movingPoint)
 
-      print("=================== Cropping =====================")                           
-      self.vsc.vtVars['fixedCropPath'] = self.vsc.runCropping(fixedVolumeNode, fixedPointT,self.vsc.vtVars['croppingLength'],  self.vsc.vtVars['RSxyz'],  self.vsc.vtVars['hrChk'],0)                    
+      print("=================== Cropping =====================")
+      self.vsc.vtVars['fixedCropPath'] = self.vsc.runCropping(fixedVolumeNode, fixedPointT,self.vsc.vtVars['croppingLength'],  self.vsc.vtVars['RSxyz'],  self.vsc.vtVars['hrChk'],0)
       [success, croppedFixedNode] = slicer.util.loadVolume(self.vsc.vtVars['fixedCropPath'], returnNode=True)
-      croppedFixedNode.SetName(fixedVolumeNode.GetName()+"_F_Crop")                                                        
-      
-      self.vsc.vtVars['movingCropPath'] = self.vsc.runCropping(movingVolumeNode, movingPointT,self.vsc.vtVars['croppingLength'],  self.vsc.vtVars['RSxyz'],  self.vsc.vtVars['hrChk'],0)                    
+      croppedFixedNode.SetName(fixedVolumeNode.GetName()+"_F_Crop")
+
+      self.vsc.vtVars['movingCropPath'] = self.vsc.runCropping(movingVolumeNode, movingPointT,self.vsc.vtVars['croppingLength'],  self.vsc.vtVars['RSxyz'],  self.vsc.vtVars['hrChk'],0)
       [success, croppedMovingNode] = slicer.util.loadVolume(self.vsc.vtVars['movingCropPath'], returnNode=True)
-      croppedMovingNode.SetName(movingVolumeNode.GetName()+"_M_Crop")                                                        
+      croppedMovingNode.SetName(movingVolumeNode.GetName()+"_M_Crop")
       print ("************  Register cropped moving image to cropped fixed image **********************")
       cTI = self.vsc.runElastix(self.vsc.vtVars['elastixBinPath'],self.vsc.vtVars['fixedCropPath'],  self.vsc.vtVars['movingCropPath'], self.vsc.vtVars['outputPath'], self.vsc.vtVars['parsPath'], self.vsc.vtVars['noOutput'], "336")
       #copyfile(resTransPathOld, resTransPath)
-      #genrates deformation field 
+      #genrates deformation field
       cTR = self.vsc.runTransformix(self.vsc.vtVars['transformixBinPath'],self.vsc.vtVars['movingCropPath'], self.vsc.vtVars['outputPath'], resTransPath, self.vsc.vtVars['noOutput'], "339")
       # rename fthe file:
-      os.rename(resOldDefPath,resDefPath)   
+      os.rename(resOldDefPath,resDefPath)
 
       print ("************  Load deformation field Transform  **********************")
       [success, vtTransformNode] = slicer.util.loadTransform(resDefPath, returnNode = True)
-      vtTransformNode.SetName(transNodeName)   
-      print ("************  Transform The Original Moving image **********************")  
-      movingVolumeNode.SetAndObserveTransformNodeID(vtTransformNode.GetID()) 
+      vtTransformNode.SetName(transNodeName)
+      print ("************  Transform The Original Moving image **********************")
+      movingVolumeNode.SetAndObserveTransformNodeID(vtTransformNode.GetID())
       #export seg to lbl then export back with input image as reference
       slicer.vtkSlicerTransformLogic().hardenTransform(movingVolumeNode)     # apply the transform
-      fnm = os.path.join(self.vsc.vtVars['outputPath'] , movingVolumeNode.GetName()+"_Registered.nrrd")                             
-      sR = slicer.util.saveNode(movingVolumeNode, fnm )  
+      fnm = os.path.join(self.vsc.vtVars['outputPath'] , movingVolumeNode.GetName()+"_Registered.nrrd")
+      sR = slicer.util.saveNode(movingVolumeNode, fnm )
       [success, registeredMovingVolumeNode] = slicer.util.loadVolume(fnm, returnNode = True)
       registeredMovingVolumeNode.SetName(movingVolumeNode.GetName()+"_Registered")
       #remove the tempnode and load the original
-      slicer.mrmlScene.RemoveNode(movingVolumeNode); 
+      slicer.mrmlScene.RemoveNode(movingVolumeNode)
       [success, movingVolumeNode] = slicer.util.loadVolume(movingPath, returnNode = True)
       movingVolumeNode.SetName(os.path.splitext(os.path.basename(movingVolumeNode.GetStorageNode().GetFileName()))[0])
       if  (cTI==0) and (cTR==0):
@@ -346,13 +346,13 @@ class CochleaRegLogic(ScriptedLoadableModuleLogic):
       #endif
 
       #Remove temporary files and nodes:
-      self.vsc.removeTmpsFiles()     
+      self.vsc.removeTmpsFiles()
       print("================= Cochlea registration is complete  =====================")
       logging.info('Processing completed')
-                        
+
       return registeredMovingVolumeNode
-    #enddef 
-  
+    #enddef
+
 #===================================================================
 #                           Test
 #===================================================================
@@ -360,7 +360,7 @@ class CochleaRegTest(ScriptedLoadableModuleTest):
   def setUp(self):
     slicer.mrmlScene.Clear(0)
   #enddef
-  
+
   def runTest(self):
       self.setUp()
       self.testSlicerCochleaRegistration()
@@ -375,12 +375,12 @@ class CochleaRegTest(ScriptedLoadableModuleTest):
       #endif
       if movingPoint is None:
           movingPoint = [196,217,93]
-      #endif 
+      #endif
       nodeNames='P100001_DV_L_a'
       fileNames='P100001_DV_L_a.nrrd'
       urisUniKo         = "https://cloud.uni-koblenz-landau.de/s/EwQiQidXqTcGySB/download"
       urisGitHub   = 'https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/P100001_DV_L_a.nrrd'
-      uris = urisGitHub          
+      uris = urisGitHub
       checksums='SHA256:d7cda4e106294a59591f03e74fbe9ecffa322dd1a9010b4d0590b377acc05eb5'
       if fixedImgPath is None:
          tmpVolumeNode =  SampleData.downloadFromURL(uris, fileNames, nodeNames, checksums )[0]
@@ -388,7 +388,7 @@ class CochleaRegTest(ScriptedLoadableModuleTest):
          slicer.mrmlScene.RemoveNode(tmpVolumeNode)
       else:
          nodeNames = os.path.splitext(os.path.basename(fixedImgPath))[0]
-      #endif 
+      #endif
       [success, fixedVolumeNode]  = slicer.util.loadVolume(fixedImgPath, returnNode=True)
       fixedVolumeNode.SetName(nodeNames)
       #endifelse
@@ -396,7 +396,7 @@ class CochleaRegTest(ScriptedLoadableModuleTest):
       fileNames='P100001_DV_L_b.nrrd'
       urisUniKo    = "https://cloud.uni-koblenz-landau.de/s/qMG2WPjTXabzcbX/download"
       urisGitHub   = 'https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/P100001_DV_L_b.nrrd'
-      uris = urisGitHub          
+      uris = urisGitHub
       checksums='SHA256:9a5722679caa978b1a566f4a148c8759ce38158ca75813925a2d4f964fdeebf5'
       if movingImgPath is None:
          tmpVolumeNode =  SampleData.downloadFromURL(uris, fileNames, nodeNames, checksums )[0]
@@ -404,35 +404,35 @@ class CochleaRegTest(ScriptedLoadableModuleTest):
          slicer.mrmlScene.RemoveNode(tmpVolumeNode)
       else:
          nodeNames = os.path.splitext(os.path.basename(movingImgPath))[0]
-      #endif 
+      #endif
       [success, movingVolumeNode] = slicer.util.loadVolume(movingImgPath, returnNode=True)
       movingVolumeNode.SetName(nodeNames)
-      #endifelse 
+      #endifelse
       self.logic = CochleaRegLogic()
-      self.vsc   = VisSimCommon.VisSimCommonLogic()   
-      #setGlobal variables. 
+      self.vsc   = VisSimCommon.VisSimCommonLogic()
+      #setGlobal variables.
       self.vsc.vtVars = self.vsc.setGlobalVariables(0)
 
       # remove contents of output folder
       self.vsc.removeOtputsFolderContents()
 
       # record duration of the test
-    
-      # create a fiducial node for cochlea locations for cropping    
-      fixedPointRAS = self.vsc.ptIJK2RAS(fixedPoint , fixedVolumeNode) 
+
+      # create a fiducial node for cochlea locations for cropping
+      fixedPointRAS = self.vsc.ptIJK2RAS(fixedPoint , fixedVolumeNode)
       fixedFiducialNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
       fixedFiducialNode.CreateDefaultDisplayNodes()
-      fixedFiducialNode.SetName("F_cochleaLocationPoint")  
+      fixedFiducialNode.SetName("F_cochleaLocationPoint")
       fixedFiducialNode.AddFiducialFromArray(fixedPointRAS)
       fixedFiducialNode.SetNthFiducialLabel(0, "F_CochleaLocation")
 
-      movingPointRAS = self.vsc.ptIJK2RAS(movingPoint , movingVolumeNode) 
+      movingPointRAS = self.vsc.ptIJK2RAS(movingPoint , movingVolumeNode)
       movingFiducialNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
       movingFiducialNode.CreateDefaultDisplayNodes()
-      movingFiducialNode.SetName("M_cochleaLocationPoint")  
+      movingFiducialNode.SetName("M_cochleaLocationPoint")
       movingFiducialNode.AddFiducialFromArray(movingPointRAS)
       movingFiducialNode.SetNthFiducialLabel(0, "M_CochleaLocation")
-      
+
       # run the segmentation
       registeredMovingVolumeNode = self.logic.run(fixedVolumeNode, fixedFiducialNode, movingVolumeNode, movingFiducialNode)
 
@@ -441,12 +441,12 @@ class CochleaRegTest(ScriptedLoadableModuleTest):
          self.vsc.fuseTwoImages(fixedVolumeNode, registeredMovingVolumeNode , True)
       except Exception as e:
              print("Can not display results! probably an external call ...")
-             print(e)   
-      #endtry  
-        
+             print(e)
+      #endtry
+
       self.etm=time.time()
       tm=self.etm - self.stm
       print("Time: "+str(tm)+"  seconds")
       self.delayDisplay('Test testSlicerCochleaRegistration passed!')
-  #enddef          
+  #enddef
 #endclass

--- a/CochleaSeg/CochleaSeg.py
+++ b/CochleaSeg/CochleaSeg.py
@@ -1,15 +1,15 @@
-#======================================================================================
-#  3D Slicer [1] plugin that uses elastix toolbox [2] Plugin for Automatic Cochlea    # 
+#=====================================================================================
+#  3D Slicer [1] plugin that uses elastix toolbox [2] Plugin for Automatic Cochlea    #
 #  Image Segmentation [3]. More info can be found at [4].                             #
 #  Sample cochlea datasets can be downloaded using Slicer Datastore module            #
 #                                                                                     #
-#  Contributers:                                                                      #   
+#  Contributers:                                                                      #
 #      - Christopher L. Guy,   guycl@vcu.edu              : Original source code.     #
 #      - Ibraheem Al-Dhamari,  idhamari@uni-koblenz.de    : Plugin design.            #
 #      - Michel Peltriaux,     mpeltriaux@uni-koblenz.de  : Programming & testing.    #
 #      - Anna Gessler,         agessler@uni-koblenz.de    : Programming & testing.    #
 #      - Jasper Grimmig        jgrimmig@uni-koblenz.de    : Programming & testing.    #
-#      - Pepe Eulzer           eulzer@uni-koblenz.de      : Programming & testing.    #  
+#      - Pepe Eulzer           eulzer@uni-koblenz.de      : Programming & testing.    #
 #  [1] https://www.slicer.org                                                         #
 #  [2] http://elastix.isi.uu.nl                                                       #
 #  [3] Al-Dhamari et al.,(2018), Automatic Cochlear Length and Volume Size Estimation #
@@ -21,10 +21,10 @@
 #  Slicer 4.11.0                                                                      #
 #  Updated: 24.6.2019                                                                 #
 #-------------------------------------------------------------------------------------#
-#  - Add branches to github to support new Slicer versions                            #                              
+#  - Add branches to github to support new Slicer versions                            #
 #  - Using VisSimCommon for shared functions.                                         #
 #  - Use transformation directly to transform the points.                             #
-#  - Add more support for windows and mac.                                            #   
+#  - Add more support for windows and mac.                                            #
 #  - Logic functions are independent and can be called from external script.          #
 #  - test function can be used in external scripts. A demo example is provided        #
 #======================================================================================
@@ -43,26 +43,26 @@ import VisSimCommon
 
 # 1. solve right model problem:
 #    - it seems hardening transform does not work after loading the segmentation. Slicer crashes.
-#      with error : Failed to get reference image geometry 
+#      with error : Failed to get reference image geometry
 #    - the problem above solved by exporting to label with model as reference then export to .seg.
-#      but still we have bad results. More testing is needed.    
-# 2. cleaning, removing temp nodes and files  
+#      but still we have bad results. More testing is needed.
+# 2. cleaning, removing temp nodes and files
 # 3. add alternative links for models and sample images.
-# 4. local testing with different machines. 
+# 4. local testing with different machines.
 
 # Later:
-# - Checking if all above are needed 
-# - Cleaning, optimizing, commenting.  
-# - Testing in both Windows and Linux. 
-# - Supporting DICOM. 
-# - Supporting illegal filename.  
-# - Add alternative to use elastix binaries directly by downloading the binary release.   
-# - Visualizing the interimediate steps. 
-# 
-#  
-#  
+# - Checking if all above are needed
+# - Cleaning, optimizing, commenting.
+# - Testing in both Windows and Linux.
+# - Supporting DICOM.
+# - Supporting illegal filename.
+# - Add alternative to use elastix binaries directly by downloading the binary release.
+# - Visualizing the interimediate steps.
+#
+#
+#
 # Terminology
-#  img         : ITK image 
+#  img         : ITK image
 #  imgNode     : Slicer Node
 #  imgName     :  Filename without the path and without extension
 #  imgPath     : wholePath + Filename and extension
@@ -82,7 +82,7 @@ class CochleaSeg(ScriptedLoadableModule):
                                "Michel Peltriauxe",
                                "Anna Gessler",
                                "Jasper Grimmig",
-                               "Pepe Eulzer"  
+                               "Pepe Eulzer"
          ]
         self.parent.helpText += self.getDefaultModuleDocumentationLink()
         parent.acknowledgementText = " This work is sponsored by Cochlear as part of COMBS project "
@@ -90,7 +90,7 @@ class CochleaSeg(ScriptedLoadableModule):
   #end def init
 #end class CochleaSeg
 
-    
+
 #===================================================================
 #                           Main Widget
 #===================================================================
@@ -99,30 +99,30 @@ class CochleaSegWidget(ScriptedLoadableModuleWidget):
 
   def setup(self):
     print(" ")
-    print("=======================================================")   
+    print("=======================================================")
     print("   Automatic Cochlea Image Segmentation               ")
-    print("=======================================================")           
+    print("=======================================================")
 
     ScriptedLoadableModuleWidget.setup(self)
-    
+
     # to access logic class functions and setup global variables
     self.logic = CochleaSegLogic()
 
-    # Set default VisSIm location in the user home 
-    #TODO: add option user-defined path when installed first time 
-    self.vsc   = VisSimCommon.VisSimCommonLogic()   
+    # Set default VisSIm location in the user home
+    #TODO: add option user-defined path when installed first time
+    self.vsc   = VisSimCommon.VisSimCommonLogic()
     self.vsc.setGlobalVariables(0)
-    
-    #----------------------------------------------------------------- 
+
+    #-----------------------------------------------------------------
     #                     Create the GUI interface
-    #----------------------------------------------------------------- 
-    # Create main collapsible Button 
+    #-----------------------------------------------------------------
+    # Create main collapsible Button
     self.mainCollapsibleBtn = ctk.ctkCollapsibleButton()
     self.mainCollapsibleBtn.setStyleSheet("ctkCollapsibleButton { background-color: DarkSeaGreen  }")
     self.mainCollapsibleBtn.text = "ACIR: Automatic Cochlea Image segmentation"
     self.layout.addWidget(self.mainCollapsibleBtn)
     self.mainFormLayout = qt.QFormLayout(self.mainCollapsibleBtn)
-  
+
     # Create input Volume Selector
     self.inputSelectorCoBx = slicer.qMRMLNodeComboBox()
     self.inputSelectorCoBx.nodeTypes = ["vtkMRMLScalarVolumeNode"]
@@ -138,21 +138,21 @@ class CochleaSegWidget(ScriptedLoadableModuleWidget):
 
     # Create a time label
     self.timeLbl = qt.QLabel("                 Time: 00:00")
-    self.timeLbl.setFixedWidth(500)   
+    self.timeLbl.setFixedWidth(500)
     self.tmLbl = self.timeLbl
-    
+
     # Create a textbox for cochlea location
     # TODO activate input IJK values as well
     self.inputPointEdt = qt.QLineEdit()
     self.inputPointEdt.setFixedHeight(40)
     self.inputPointEdt.setText("[0,0,0]")
-    
+
     # Create a cochlea locator button
     self.inputFiducialBtn = qt.QPushButton("Pick cochlea location in input image    ")
     self.inputFiducialBtn.setFixedHeight(40)
     self.inputFiducialBtn.setToolTip("Pick the input fiducial point that will be the center of the cropped image")
     self.inputFiducialBtn.connect('clicked(bool)', lambda: self.onInputFiducialBtnClick("input"))
-    self.mainFormLayout.addRow( self.inputFiducialBtn, self.inputPointEdt)    
+    self.mainFormLayout.addRow( self.inputFiducialBtn, self.inputPointEdt)
 
 
     # Create a button to run segmentation
@@ -164,17 +164,17 @@ class CochleaSegWidget(ScriptedLoadableModuleWidget):
     self.applyBtn.connect('clicked(bool)', self.onApplyBtnClick)
     self.mainFormLayout.addRow(self.applyBtn, self.timeLbl)
     self.runBtn = self.applyBtn
-    
-    # Add check box for right ear side  
+
+    # Add check box for right ear side
     self.sideChkBox = qt.QCheckBox()
     self.sideChkBox.text = "Right side cochlea"
     self.sideChkBox.stateChanged.connect(self.onSideChkBoxChange)
-    self.mainFormLayout.addRow(self.sideChkBox) 
-    
-    # Create and link Btn to update measuerments    
+    self.mainFormLayout.addRow(self.sideChkBox)
+
+    # Create and link Btn to update measuerments
     self.updateLengthBtn = qt.QPushButton("Update Length")
     self.updateLengthBtn.setFixedHeight(40)
-    self.updateLengthBtn.setFixedWidth(250)        
+    self.updateLengthBtn.setFixedWidth(250)
     self.updateLengthBtn.toolTip = ('How to use:' ' Run segmentation first. ')
     self.updateLengthBtn.connect('clicked(bool)', self.onUpdateLengthBtnClick)
     self.mainFormLayout.addRow(self.updateLengthBtn )
@@ -191,47 +191,47 @@ class CochleaSegWidget(ScriptedLoadableModuleWidget):
       self.vsc.setItemChk("cochleaSide", self.sideChkBox.checked, "cochleaSide", nodes)
   #enddef
 
-  # Create a button for updating the cochlea length if the 
+  # Create a button for updating the cochlea length if the
   #  the user move some fiducial points
   def onUpdateLengthBtnClick(self):
       nodes = slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode')
       for f in nodes:
           if ( "_StPts" in f.GetName()) :
-             vtImgStNode = f  
-             break   
+             vtImgStNode = f
+             break
           #endif
-      #endfor      
-  
+      #endfor
+
       nodes = slicer.util.getNodesByClass('vtkMRMLTableNode')
       for f in nodes:
           if ( "_tbl" in f.GetName() ):
-             spTblNode = f  
-             break   
+             spTblNode = f
+             break
           #endif
-      #endfor      
+      #endfor
       self.vsc.getFiducilsDistance(vtImgStNode, spTblNode)
   #enddef
 
-  def onInputFiducialBtnClick(self,volumeType):       
-      self.inputFiducialBtn.setStyleSheet("QPushButton{ background-color: White  }")   
- 
+  def onInputFiducialBtnClick(self,volumeType):
+      self.inputFiducialBtn.setStyleSheet("QPushButton{ background-color: White  }")
+
       self.inputVolumeNode=self.inputSelectorCoBx.currentNode()
-      self.logic.inputFiducialNode = None    
+      self.logic.inputFiducialNode = None
       #remove old nodes
 
       nodes = slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode')
       for f in nodes:
           if ((f.GetName() == self.inputVolumeNode.GetName()+"_CochleaLocation") ):
-             #replace  current 
+             #replace  current
              #print("inputFiducialNode exist")
-             self.logic.inputFiducialNode = f  
+             self.logic.inputFiducialNode = f
              newNode= False
             #endif
-      #endfor    
+      #endfor
       if not hasattr(self.vsc, 'vtVars'):
          self.vsc.setGlobalVariables(0)
-      #end 
-      self.vsc.locateItem(self.inputSelectorCoBx.currentNode(), self.inputPointEdt, 0 , 0)    
+      #end
+      self.vsc.locateItem(self.inputSelectorCoBx.currentNode(), self.inputPointEdt, 0 , 0)
       self.logic.inputFiducialNode= self.vsc.inputFiducialNodes[0]
 
       self.inputFiducialBtn.setStyleSheet("QPushButton{ background-color: DarkSeaGreen  }")
@@ -245,7 +245,7 @@ class CochleaSegWidget(ScriptedLoadableModuleWidget):
       self.stm=time.time()
       print("time:" + str(self.stm))
       self.timeLbl.setText("                 Time: 00:00")
-    
+
       self.logic.run( self.inputSelectorCoBx.currentNode(),self.logic.inputFiducialNode, self.vsc.vtVars['cochleaSide'] )
 
       slicer.app.layoutManager().setLayout( slicer.modules.tables.logic().GetLayoutWithTable(slicer.app.layoutManager().layout))
@@ -259,160 +259,160 @@ class CochleaSegWidget(ScriptedLoadableModuleWidget):
       self.runBtn.setStyleSheet("QPushButton{ background-color: DarkSeaGreen  }")
       slicer.app.processEvents()
   #enddef
-  
+
 #===================================================================
 #                           Logic
 #===================================================================
 class CochleaSegLogic(ScriptedLoadableModuleLogic):
-  #--------------------------------------------------------------------------------------------        
-  #                       Segmentation Process 
-  #--------------------------------------------------------------------------------------------        
+  #--------------------------------------------------------------------------------------------
+  #                       Segmentation Process
+  #--------------------------------------------------------------------------------------------
   # This method perform the atlas segementation steps
   def run(self, inputVolumeNode, inputFiducialNode, cochleaSide):
       logging.info('Processing started')
- 
+
       self.vsc   = VisSimCommon.VisSimCommonLogic()
       self.vsc.setGlobalVariables(0)
 
       self.inputVolumeNode = inputVolumeNode
       self.inputFiducialNode = inputFiducialNode
       # modality type CBCT, CT or MRI
-      # it seems using CBCT atlas is enough 
+      # it seems using CBCT atlas is enough
       Styp="Dv"
 
       # segmentation atlas model paths
-                     
-      modelPath      =   self.vsc.vtVars['modelPath']+ ",Mdl"+Styp +cochleaSide +"c"+self.vsc.vtVars['imgType'] 
+
+      modelPath      =   self.vsc.vtVars['modelPath']+ ",Mdl"+Styp +cochleaSide +"c"+self.vsc.vtVars['imgType']
       modelPath      =   os.path.join(*modelPath.split(","))
-      modelSegPath   =   self.vsc.vtVars['modelPath']+ ",Mdl"+Styp +cochleaSide +"cS.seg"+self.vsc.vtVars['imgType']        
+      modelSegPath   =   self.vsc.vtVars['modelPath']+ ",Mdl"+Styp +cochleaSide +"cS.seg"+self.vsc.vtVars['imgType']
       modelSegPath   =   os.path.join(*modelSegPath.split(","))
-      modelImgStPath =   self.vsc.vtVars['modelPath']+ ",Mdl"+Styp +cochleaSide +"cSt.fcsv"       
-      modelImgStPath   =   os.path.join(*modelImgStPath.split(","))       
-      # set the results paths:       
+      modelImgStPath =   self.vsc.vtVars['modelPath']+ ",Mdl"+Styp +cochleaSide +"cSt.fcsv"
+      modelImgStPath   =   os.path.join(*modelImgStPath.split(","))
+      # set the results paths:
       resTransPathOld  = os.path.join(self.vsc.vtVars['outputPath'] ,"TransformParameters.0.txt")
-      resTransPath=resTransPathOld[0:-6]+'Pars.txt'        
+      resTransPath=resTransPathOld[0:-6]+'Pars.txt'
       resOldDefPath = os.path.join(self.vsc.vtVars['outputPath'] , "deformationField"+self.vsc.vtVars['imgType'])
       resDefPath    = os.path.join(self.vsc.vtVars['outputPath'] , inputVolumeNode.GetName()+"_dFld"+self.vsc.vtVars['imgType'])
       inputImgName  = inputVolumeNode.GetStorageNode().GetFileName()
-      inputImgName  = os.path.basename(os.path.splitext(inputImgName)[0])    
-        
-      segNodeName   = inputVolumeNode.GetName() + "_S.Seg"                 
+      inputImgName  = os.path.basename(os.path.splitext(inputImgName)[0])
+
+      segNodeName   = inputVolumeNode.GetName() + "_S.Seg"
       stpNodeName   = inputVolumeNode.GetName() + "_StPts"
       transNodeName = inputVolumeNode.GetName() + "_Transform"
 
       self.vsc.removeOtputsFolderContents()
       # check if the model is found
-      if not os.path.isfile(modelPath): 
+      if not os.path.isfile(modelPath):
             print("ERROR: model is not found", file=sys.stderr)
             print("modelPath: " + modelPath)
             return -1
       # endif
 
-      # Get IJK point from the fiducial to use in cropping          
+      # Get IJK point from the fiducial to use in cropping
       inputPoint = self.vsc.ptRAS2IJK(inputFiducialNode,inputVolumeNode,0)
       # TODO: add better condition
       if  np.sum(inputPoint)== 0 :
             print("Error: select cochlea point")
             return -1
-      #endif  
-      fnm = os.path.join(self.vsc.vtVars['outputPath'] , inputVolumeNode.GetName()+"_Cochlea_Pos.fcsv")                           
-      sR = slicer.util.saveNode(inputFiducialNode, fnm )  
+      #endif
+      fnm = os.path.join(self.vsc.vtVars['outputPath'] , inputVolumeNode.GetName()+"_Cochlea_Pos.fcsv")
+      sR = slicer.util.saveNode(inputFiducialNode, fnm )
 
       #Remove old resulted nodes
       for node in slicer.util.getNodes():
           if ( segNodeName   == node): slicer.mrmlScene.RemoveNode(node) #endif
           if ( transNodeName == node): slicer.mrmlScene.RemoveNode(node) #endif
-      #endfor    
-        
-      inputPointT = self.vsc.v2t(inputPoint) 
-        
-      print("=================== Cropping =====================")                           
-      self.vsc.vtVars['intputCropPath'] = self.vsc.runCropping(inputVolumeNode, inputPointT,self.vsc.vtVars['croppingLength'],  self.vsc.vtVars['RSxyz'],  self.vsc.vtVars['hrChk'],0)                    
+      #endfor
+
+      inputPointT = self.vsc.v2t(inputPoint)
+
+      print("=================== Cropping =====================")
+      self.vsc.vtVars['intputCropPath'] = self.vsc.runCropping(inputVolumeNode, inputPointT,self.vsc.vtVars['croppingLength'],  self.vsc.vtVars['RSxyz'],  self.vsc.vtVars['hrChk'],0)
       [success, croppedNode] = slicer.util.loadVolume(self.vsc.vtVars['intputCropPath'], returnNode=True)
-      croppedNode.SetName(inputVolumeNode.GetName()+"_Crop")                                                        
+      croppedNode.SetName(inputVolumeNode.GetName()+"_Crop")
       print ("************  Register model to cropped input image **********************")
       cTI = self.vsc.runElastix(self.vsc.vtVars['elastixBinPath'],self.vsc.vtVars['intputCropPath'],  modelPath, self.vsc.vtVars['outputPath'], self.vsc.vtVars['parsPath'], self.vsc.vtVars['noOutput'], "292")
       copyfile(resTransPathOld, resTransPath)
-      #genrates deformation field 
+      #genrates deformation field
       cTR = self.vsc.runTransformix(self.vsc.vtVars['transformixBinPath'],modelPath, self.vsc.vtVars['outputPath'], resTransPath, self.vsc.vtVars['noOutput'], "295")
       # rename fthe file:
-      os.rename(resOldDefPath,resDefPath)   
+      os.rename(resOldDefPath,resDefPath)
       print ("************  Load deformation field Transform  **********************")
       [success, vtTransformNode] = slicer.util.loadTransform(resDefPath, returnNode = True)
-      vtTransformNode.SetName(transNodeName)   
-      print ("************  Transform The Segmentation **********************")     
+      vtTransformNode.SetName(transNodeName)
+      print ("************  Transform The Segmentation **********************")
       [success, vtSegNode] = slicer.util.loadSegmentation(modelSegPath, returnNode = True)
       vtSegNode.SetName(segNodeName)
-      vtSegNode.SetAndObserveTransformNodeID(vtTransformNode.GetID()) 
+      vtSegNode.SetAndObserveTransformNodeID(vtTransformNode.GetID())
       #export seg to lbl then export back with input image as reference
       slicer.vtkSlicerTransformLogic().hardenTransform(vtSegNode)     # apply the transform
-      vtSegNode.CreateClosedSurfaceRepresentation() 
-      fnm = os.path.join(self.vsc.vtVars['outputPath'] , vtSegNode.GetName()+".nrrd")                             
-      sR = slicer.util.saveNode(vtSegNode, fnm )  
+      vtSegNode.CreateClosedSurfaceRepresentation()
+      fnm = os.path.join(self.vsc.vtVars['outputPath'] , vtSegNode.GetName()+".nrrd")
+      sR = slicer.util.saveNode(vtSegNode, fnm )
 
       print ("************  Transform The Scala Points **********************")
       #TODO:check the right side model
       #TODO:add scala vestibuli model
-      # transform the Scala Tympani Points for length Computation 
+      # transform the Scala Tympani Points for length Computation
       [success, vtImgStNode] = slicer.util.loadMarkupsFiducialList  (modelImgStPath, returnNode = True)
-      vtImgStNode.GetDisplayNode().SetSelectedColor(1,0,0)  
-      vtImgStNode.GetDisplayNode().SetTextScale(0.5)                               
+      vtImgStNode.GetDisplayNode().SetSelectedColor(1,0,0)
+      vtImgStNode.GetDisplayNode().SetTextScale(0.5)
       vtImgStNode.SetName(stpNodeName)
-      vtImgStNode.SetAndObserveTransformNodeID(vtTransformNode.GetID()) 
+      vtImgStNode.SetAndObserveTransformNodeID(vtTransformNode.GetID())
       slicer.vtkSlicerTransformLogic().hardenTransform(vtImgStNode) # apply the transform
-      fnm = os.path.join(self.vsc.vtVars['outputPath'] , vtImgStNode.GetName()+".fcsv")                             
-      sR = slicer.util.saveNode(vtImgStNode, fnm ) 
+      fnm = os.path.join(self.vsc.vtVars['outputPath'] , vtImgStNode.GetName()+".fcsv")
+      sR = slicer.util.saveNode(vtImgStNode, fnm )
 
       # Display the result if no error
       # Clear cochlea location labels
       if  (cTI==0) and (cTR==0):
-          # change the model type from vtk to stl 
+          # change the model type from vtk to stl
           msn=slicer.vtkMRMLModelStorageNode()
           msn.SetDefaultWriteFileExtension('stl')
-          slicer.mrmlScene.AddDefaultNode(msn)        
+          slicer.mrmlScene.AddDefaultNode(msn)
           print("get Cochlea information")
           tableName =  inputVolumeNode.GetName()+"_tbl"
           # create only if it does not exist
           try:
              spTblNode =  slicer.util.getNode(tableName)
           except Exception as e:
-             print(e)   
+             print(e)
              spTblNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
              spTblNode.SetName(tableName)
           #endtry
           spTblNode = self.vsc.getItemInfo( vtSegNode, croppedNode, spTblNode,0)
           for i in range (0,8):
               spTblNode.RemoveColumn(3)
-          #endfor           
+          #endfor
           spTblNode.GetTable().GetColumn(1).SetName("Size (mm^3)")
-          spTblNode.GetTable().GetColumn(2).SetName("Length (mm)")   
+          spTblNode.GetTable().GetColumn(2).SetName("Length (mm)")
           spTblNode.SetCellText(0,0,"Scala Tympani")
           spTblNode.SetCellText(1,0,"Scala Vestibuli")
-          #spTblNode.resultsTableNode.SetCellText(0,2,"ST value")   
-          #spTblNode.resultsTableNode.SetCellText(1,2,"0")   
+          #spTblNode.resultsTableNode.SetCellText(0,2,"ST value")
+          #spTblNode.resultsTableNode.SetCellText(1,2,"0")
 
-          self.vsc.getFiducilsDistance(vtImgStNode,spTblNode )      
-          spTblNode.RemoveRow(spTblNode.GetNumberOfRows())              
-          self.spTblNode=spTblNode                     
+          self.vsc.getFiducilsDistance(vtImgStNode,spTblNode )
+          spTblNode.RemoveRow(spTblNode.GetNumberOfRows())
+          self.spTblNode=spTblNode
       else:
            print("error happened during segmentation ")
       #endif
 
       #Remove temporary files and nodes:
-      self.vsc.removeTmpsFiles()     
+      self.vsc.removeTmpsFiles()
       print("================= Cochlea analysis is complete  =====================")
       logging.info('Processing completed')
       return vtSegNode
 
     #enddef
- 
+
 #===================================================================
 #                           Test
 #===================================================================
 class CochleaSegTest(ScriptedLoadableModuleTest):
   def setUp(self):
       slicer.mrmlScene.Clear(0)
-  #endef   
+  #endef
 
   def runTest(self):
       self.setUp()
@@ -424,19 +424,19 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
       self.delayDisplay("Starting testSlicerCochleaSegmentation test")
       self.stm=time.time()
 
-      self.vsc   = VisSimCommon.VisSimCommonLogic()   
+      self.vsc   = VisSimCommon.VisSimCommonLogic()
       self.vsc.vtVars = self.vsc.setGlobalVariables(0)
       self.logic = CochleaSegLogic()
       # remove contents of output folder
       self.vsc.removeOtputsFolderContents()
       #TODO: error handling to select the download link
       if cochleaSide is None:
-         cochleaSide  = "L"  ;    beforORafter ="_b" # _a= before, _b=after     
-         if ( cochleaSide=="L" and beforORafter=="_b" ):        
+         cochleaSide  = "L"  ;    beforORafter ="_b" # _a= before, _b=after
+         if ( cochleaSide=="L" and beforORafter=="_b" ):
              cochleaPoint = [195,218,95]
              urisUniKo    = "https://cloud.uni-koblenz-landau.de/s/qMG2WPjTXabzcbX/download"
              urisGitHub   = 'https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/P100001_DV_L_b.nrrd'
-             uris = urisGitHub          
+             uris = urisGitHub
              fileNames    = 'P100001_DV_L_b.nrrd'
              nodeNames    = 'P100001_DV_L_b'
              checksums    = 'SHA256:9a5722679caa978b1a566f4a148c8759ce38158ca75813925a2d4f964fdeebf5'
@@ -444,7 +444,7 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
              cochleaPoint = [214,242,78]
              urisUniKo         = "https://cloud.uni-koblenz-landau.de/s/EwQiQidXqTcGySB/download"
              urisGitHub   = 'https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/P100001_DV_L_a.nrrd'
-             uris = urisGitHub          
+             uris = urisGitHub
              fileNames    = 'P100001_DV_L_a.nrrd'
              nodeNames    = 'P100001_DV_L_a'
              checksums    = 'SHA256:d7cda4e106294a59591f03e74fbe9ecffa322dd1a9010b4d0590b377acc05eb5'
@@ -452,24 +452,24 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
              cochleaPoint = [194,216,93]
              urisUniKo   = "https://cloud.uni-koblenz-landau.de/s/4K5gAwisgqSHK4j/download"
              urisGitHub   = 'https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/P100003_DV_R_b.nrrd'
-             uris = urisGitHub          
-             fileNames    = 'P100003_DV_R_b.nrrd' 
+             uris = urisGitHub
+             fileNames    = 'P100003_DV_R_b.nrrd'
              nodeNames    = 'P100003_DV_R_b'
              checksums    = 'SHA256:4478778377982b6789ddf8f5ccd20f66757d6733853cce3f89faf75df2fa4faa'
          elif(cochleaSide=="R" and beforORafter=="_a" ):
              cochleaPoint = [294,250,60]
              urisUniKo    = "https://cloud.uni-koblenz-landau.de/s/WAxHyqLC3JsKY2x/download"
              urisGitHub   = 'https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/P100003_DV_R_a.nrrd'
-             uris = urisGitHub          
+             uris = urisGitHub
              fileNames    = 'P100003_DV_R_a.nrrd'
              nodeNames    = 'P100003_DV_R_a'
              checksums    = 'SHA256:c62d37e13596eafc8550f488006995d811c8d6503445d5324810248a3c3b6f89'
          else:
              print("error in cochlea side or before after type")
              return -1
-      #endif  
+      #endif
       #sampledata loads the volume as well but didn't provide storage node.
-      if imgPath is None: 
+      if imgPath is None:
          try:
             tmpVolumeNode =  SampleData.downloadFromURL(uris, fileNames, nodeNames, checksums )[0]
             imgPath       =  os.path.join(slicer.mrmlScene.GetCacheManager().GetRemoteCacheDirectory(),fileNames)
@@ -477,19 +477,19 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
          except Exception as e:
             print("Error: can not download sample data")
             print (e)
-            return -1 
+            return -1
          #endtry
       else:
          nodeNames = os.path.splitext(os.path.basename(imgPath))[0]
-      #endif 
+      #endif
       [success, inputVolumeNode]  = slicer.util.loadVolume(imgPath, returnNode=True)
       inputVolumeNode.SetName(nodeNames)
 
-      # create a fiducial node for cochlea location for cropping    
-      cochleaPointRAS = self.vsc.ptIJK2RAS(cochleaPoint,inputVolumeNode) 
+      # create a fiducial node for cochlea location for cropping
+      cochleaPointRAS = self.vsc.ptIJK2RAS(cochleaPoint,inputVolumeNode)
       inputFiducialNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
       inputFiducialNode.CreateDefaultDisplayNodes()
-      inputFiducialNode.SetName("cochleaLocationPoint")  
+      inputFiducialNode.SetName("cochleaLocationPoint")
       inputFiducialNode.AddFiducialFromArray(cochleaPointRAS)
 
       # run the segmentation
@@ -499,8 +499,8 @@ class CochleaSegTest(ScriptedLoadableModuleTest):
          self.vsc.dispSeg(inputVolumeNode,segNode,34) # 34: 4up table layout
       except Exception as e:
              print("Can not display results! probably an external call ...")
-             print(e)   
-      #endtry  
+             print(e)
+      #endtry
       self.etm=time.time()
       tm=self.etm - self.stm
       print("Time: "+str(tm)+"  seconds")

--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@
 
 This is a [3D Slicer](https://gaithub.com/Slicer/Slicer) plugin that uses [elastix toolbox](https://github.com/SuperElastix/elastix) for Multi-modal cochlea Images registration, segmentation and analysis. More information can be found [here](https://mtixnat.uni-koblenz.de). The elastix parameters file can be found [here](http://elastix.bigr.nl/wiki/index.php/Par0053)
 
-**Tested on:** 
-Slicer 4.10, Windows 10 and Ubuntu 18.04 
+**Tested on:**
+Slicer 4.10, Windows 10 and Ubuntu 18.04
 
 This project contains two modules:
 
   1. Cochlea image registration.
-  2. Cochlea image segmentation and measuerments. 
+  2. Cochlea image segmentation and measuerments.
 
 Please cite our papers:
-*  Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Rania Helal, Friedrich Lisseck and Roland Jacob, (2018), Automatic Cochlear Length and Volume Size Estimation, Accepted in: First  International Workshop on Context-Aware Operating Theater OR 2, MICCAI 2018, Granada Spain.[link](https://or20.univ-rennes1.fr/sites/or20.univ-rennes1.fr/files/asset/document/aldhamarietal2018_0.pdf)     
+*  Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Rania Helal, Friedrich Lisseck and Roland Jacob, (2018), Automatic Cochlear Length and Volume Size Estimation, Accepted in: First  International Workshop on Context-Aware Operating Theater OR 2, MICCAI 2018, Granada Spain.[link](https://or20.univ-rennes1.fr/sites/or20.univ-rennes1.fr/files/asset/document/aldhamarietal2018_0.pdf)
 
 *  Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Roland Jacob, (2018), Automatic Cochlea Multi-modal Images Segmentation Using Adaptive Stochastic Gradient Descent. In: CI2018 DC Emerging Issues in Cochlear Implantation, Washington DC, USA.
 
 *  Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Friedrich Lisseck and Roland Jacob, (2017): ACIR: automatic cochlea image registration. In: Proceedings SPIE Medical Imaging 2017: Image Processing;. SPIE. Bd. 10133. S. 10133p1-10133p5. [link](http://spie.org/Publications/Proceedings/Paper/10.1117/12.2254396)
 
-Please share your cochlea dataset with us. 
+Please share your cochlea dataset with us.
 
-Your contribution is welcome! 
+Your contribution is welcome!
 
 
 Updtae : 6/12/2018
 
 - Logic and testing classes are added. Some useful functions can be called from external modules. User can test the module using Reload and test button.
-- Runtime libraries are included. 
+- Runtime libraries are included.
 - Suppport DICOM and other formats.
 - Support filenames with spaces.
 

--- a/SlicerCochlea.s4ext
+++ b/SlicerCochlea.s4ext
@@ -30,7 +30,7 @@ iconurl https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCo
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
-status 
+status
 
 # One line stating what the module does
 description The cochlea is a very important part of the inner ear. It is responsible for the transfer of audio signals to the brain. There are two modules in this extension. The first module, Cochlea Registration, registers and fuses cochlea images from different modalities. The second plugin, Cochlea Segmenttaion, segment out the cochlea structure, scala tympani and other scalae (media and vestibuli) in addition to measure the length and the size of the scala tympani. Both modules required a few seconds to complete the tasks. They use a cusomised set of parameters for elastix toolbox. The extension will download elastix binaries and other necessary files so it will take some minutes when use first time. For testing, cochlea sample datasets can be downloaded using Slicer Data Store module. You are welcome to contribute by optimising the code or sharing your cochlea dataset. For questions or problems using this extension please post in the gitHub issue or in Slicer forum. For more details please read the related publications:
@@ -40,7 +40,7 @@ Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus and Roland Jacob, (2017): Aut
 Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Friedrich Lisseck and Roland Jacob, (2017): ACIR: automatic cochlea image registration. In: Proceedings SPIE Medical Imaging 2017: Image Processing
 
 # Space separated list of urls
-screenshoturls https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/c.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r1.png  https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r2.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s1.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s2.png 
+screenshoturls https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/c.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r1.png  https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r2.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s1.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/VisSimCommon/VisSimCommon.py
+++ b/VisSimCommon/VisSimCommon.py
@@ -1,34 +1,34 @@
 
 #======================================================================================
-#  3D Slicer [1] common functions used by VisSim extensions                           # 
+#  3D Slicer [1] common functions used by VisSim extensions                           #
 #                                                                                     #
-#  Contributers:                                                                      #   
+#  Contributers:                                                                      #
 #      - Ibraheem Al-Dhamari,  idhamari@uni-koblenz.de    : Plugin design.            #
 #  [1] https://www.slicer.org                                                         #
-#                                                                                     # 
+#                                                                                     #
 #-------------------------------------------------------------------------------------#
-#  Slicer 4.11                                                                        # 
+#  Slicer 4.11                                                                        #
 #  Updated: 24.6.2019                                                                 #
 #-------------------------------------------------------------------------------------#
 #TODO: check  Documentation/Nightly/Developers/Tutorials/MigrationGuide               #
 #-------------------------------------------------------------------------------------#
-# this file can be updated andreload automatically when call dependant module by      # 
+# this file can be updated andreload automatically when call dependant module by      #
 # modifing bin/python/slicer/ScriptedLoadableModule.py                                #
 #    def onReload(self):
 #       .
-#       . 
+#       .
 #       VisSimModules = ["CochleaSeg","CochleaReg","CervicalSpineTools","CervicalVertebraTools"]
 #       if self.moduleName in VisSimModules:
 #          print("Reloading VisSimCommon ............")
 #          slicer.util.reloadScriptedModule("VisSimCommon")
-#       slicer.util.reloadScriptedModule(self.moduleName)    
+#       slicer.util.reloadScriptedModule(self.moduleName)
 #======================================================================================
 import os, re, sys, math, unittest, logging, zipfile, platform, subprocess, hashlib
 import numpy as np
 import SimpleITK as sitk
-import sitkUtils 
+import sitkUtils
 from __main__ import vtk, qt, ctk, slicer
-from slicer.ScriptedLoadableModule import *  
+from slicer.ScriptedLoadableModule import *
 import SampleData
 
 import SegmentStatistics
@@ -42,7 +42,7 @@ class VisSimCommon(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         parent.title = "VisSim Common"
         parent.categories = ["VisSimTools"]
-        self.parent = parent        
+        self.parent = parent
   #enddef
 #endclass
 
@@ -65,7 +65,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       print("testing")
       return x+y
   #enddef
- 
+
   # vsExtension = 0: Cochlea, vsExtension = 1: Spine
   def setGlobalVariables(self,vsExtension):
       # define global variables as a dictonary
@@ -76,66 +76,66 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       self.elastixStartupInfo             = self.ElastixLogic.getStartupInfo() # to hide the console
       self.vtVars['vissimPath']           = os.path.join(os.path.expanduser("~"),"VisSimTools")
       self.vtVars['elastixBinPath']       = os.path.join(self.ElastixBinFolder, "elastix")
-      self.vtVars['transformixBinPath']   =  os.path.join(self.ElastixBinFolder, "transformix")  
+      self.vtVars['transformixBinPath']   =  os.path.join(self.ElastixBinFolder, "transformix")
       self.vtVars['winOS']                = "False"
       if (sys.platform == 'win32') or (platform.system()=='Windows'):
          self.vtVars['elastixBinPath']       = os.path.join(self.ElastixBinFolder, "elastix.exe")
          self.vtVars['transformixBinPath']   = os.path.join(self.ElastixBinFolder, "transformix.exe")
          #self.vtVars['noOutput']             = " >> /dev/null"
          self.vtVars['winOS']                     = "True"
-      #endif   
+      #endif
       self.vtVars['noOutput']             = " >> /dev/null"
       self.vtVars['outputPath']           = os.path.join(self.vtVars['vissimPath'],"outputs")
       self.vtVars['imgType']              = ".nrrd"
       self.vtVars['hrChk']                = "True"
-      self.vtVars['fixedPoint']           = "[0,0,0]" # initial poisition = no position               
-      self.vtVars['movingPoint']          = "[0,0,0]" # initial poisition = no position               
-      # change the model type from vtk to stl 
+      self.vtVars['fixedPoint']           = "[0,0,0]" # initial poisition = no position
+      self.vtVars['movingPoint']          = "[0,0,0]" # initial poisition = no position
+      # change the model type from vtk to stl
       msn=slicer.vtkMRMLModelStorageNode()
       msn.SetDefaultWriteFileExtension('stl')
       slicer.mrmlScene.AddDefaultNode(msn)
 
       if vsExtension == 0: #0=cochlea
-         self.vtVars['othersUniKoWebLink']  = ("https://cloud.uni-koblenz-landau.de/s/XYXPb4Fepms2JeC/download")  
-         self.vtVars['othersWebLink']       = ("https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/VisSimToolsCochlea.zip")  
-         self.OthersSHA256                  = '763be6b5b11f0f6a3ed73d1a5ef5df34cdbbf46a3e1728195e79e8dcd26313d1' 
+         self.vtVars['othersUniKoWebLink']  = ("https://cloud.uni-koblenz-landau.de/s/XYXPb4Fepms2JeC/download")
+         self.vtVars['othersWebLink']       = ("https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/VisSimToolsCochlea.zip")
+         self.OthersSHA256                  = '763be6b5b11f0f6a3ed73d1a5ef5df34cdbbf46a3e1728195e79e8dcd26313d1'
          self.vtVars['parsPath']            = os.path.join(self.vtVars['vissimPath'] , "pars","parCochSeg.txt")
-         self.vtVars['modelPath']           = os.path.join(self.vtVars['vissimPath'] , "models","modelCochlea")            
+         self.vtVars['modelPath']           = os.path.join(self.vtVars['vissimPath'] , "models","modelCochlea")
          self.vtVars['downSz']              = "500"
-         self.vtVars['inputPoint']          = "[0,0,0]" # initial poisition = no position               
+         self.vtVars['inputPoint']          = "[0,0,0]" # initial poisition = no position
          self.vtVars['croppingLength']      = "[ 10 , 10 , 10 ]"   #Cropping Parameters
-         self.vtVars['RSxyz']               = "[ 0.125, 0.125 , 0.125 ]"  #Resampling parameters 
+         self.vtVars['RSxyz']               = "[ 0.125, 0.125 , 0.125 ]"  #Resampling parameters
          self.vtVars['dispViewTxt']         = "Green"
          self.vtVars['cochleaSide']         = "L" # default cochlea side is left
          self.vtVars['StLength']            = "0" # initial scala tympani length
          self.vtVars['dispViewTxt']         = "Green"
-         self.vtVars['dispViewID']          = "8" #Green, coronal view 
+         self.vtVars['dispViewID']          = "8" #Green, coronal view
          if (sys.platform == 'win32') or (platform.system()=='Windows'):
            self.OthersSHA256                = 'd4c6c859b712e963cd7c115413d50e314092d3beae1cede5225fc7552d02804a'
-        #endif   
-      #Only for Cervical Spine      
-      elif vsExtension == 1: # Cervical Spine       
-         print("VisSimCommonLogic: initializing global variables:")  
+        #endif
+      #Only for Cervical Spine
+      elif vsExtension == 1: # Cervical Spine
+         print("VisSimCommonLogic: initializing global variables:")
          self.vtVars['othersUniKoWebLink']   = "https://cloud.uni-koblenz-landau.de/s/yfwcdymS9QfqKc9/download"
          self.vtVars['othersWebLink']        = "https://github.com/MedicalImageAnalysisTutorials/VisSimData/raw/master/VisSimToolsCervicalSpine.zip"
-         self.OthersSHA256                   = 'fbcd25344b649cb3055674ff740be305f0c975781726c353ef11566be1b545c0'          
+         self.OthersSHA256                   = 'fbcd25344b649cb3055674ff740be305f0c975781726c353ef11566be1b545c0'
          self.vtVars['parsPath']             = os.path.join(self.vtVars['vissimPath']  , "pars","parSpiSeg.txt" )
          self.vtVars['modelPath']            = os.path.join(self.vtVars['vissimPath']  , "models","modelCervicalSpine" )
          self.vtVars['vtID']                 = "7"
          vtMethodsegT= [",Default"]
          vtMethodsgT = ["S.seg" ]
          self.vtVars['vtMethodID']           = "0"
-         self.vtVars['segT']                 = vtMethodsegT[int(self.vtVars['vtMethodID'])] 
-         self.vtVars['sgT']                  = vtMethodsgT[int(self.vtVars['vtMethodID'])] 
-         self.vtVars['Styp']                 = "Ct"  
+         self.vtVars['segT']                 = vtMethodsegT[int(self.vtVars['vtMethodID'])]
+         self.vtVars['sgT']                  = vtMethodsgT[int(self.vtVars['vtMethodID'])]
+         self.vtVars['Styp']                 = "Ct"
          self.vtVars['vtPtsLigDir']          = ",PtsLig"
          self.vtVars['vtPtsLigSuff']         = "Lp"
          modelCropImgLigPtsTmpPath           = self.vtVars['modelPath'] +"," +self.vtVars['vtPtsLigDir']+","+self.vtVars['Styp']
-         self.vtVars['modelLigPtsPath']      = os.path.join(*modelCropImgLigPtsTmpPath.split(","))  
-         subVarsTemplateFnm                  = self.vtVars['modelPath'] +","+self.vtVars['vtPtsLigDir']+",simPackSubVars.txt"  
-         self.vtVars['subVarsTemplateFnm']   =  os.path.join(*subVarsTemplateFnm.split(","))  
+         self.vtVars['modelLigPtsPath']      = os.path.join(*modelCropImgLigPtsTmpPath.split(","))
+         subVarsTemplateFnm                  = self.vtVars['modelPath'] +","+self.vtVars['vtPtsLigDir']+",simPackSubVars.txt"
+         self.vtVars['subVarsTemplateFnm']   =  os.path.join(*subVarsTemplateFnm.split(","))
          self.vtVars['dispViewTxt']          = "Yellow"
-         self.vtVars['dispViewID']           = "7" #Yellow, sagittal view 
+         self.vtVars['dispViewID']           = "7" #Yellow, sagittal view
          self.vtVars['downSz']               = "160"
          self.vtVars['winOS']                = "False"
          self.vtVars['ligChk']               = "True"
@@ -143,12 +143,12 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
          self.vtVars['croppingLength']       = "[ 80 , 80 , 50 ]"
          self.vtVars['RSxyz']                = "[ 0.5, 0.5 , 0.5 ]"
          if (sys.platform == 'win32') or (platform.system()=='Windows'):
-           self.OthersSHA256                 = '9a2ee6a67a190e438a18be811310cbf4eb26b6ad3e00243affa44cc0b26c4393' 
-         #endif   
-      #endif             
-      #check if VisSimTools folder is found                  
+           self.OthersSHA256                 = '9a2ee6a67a190e438a18be811310cbf4eb26b6ad3e00243affa44cc0b26c4393'
+         #endif
+      #endif
+      #check if VisSimTools folder is found
       self.checkVisSimTools(self.vtVars,vsExtension)
-      
+
       return self.vtVars
   #enddef
 
@@ -157,58 +157,58 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
 
       print(" Defaults paths: " )
       print("      VisSimTools folder: " + vtVars['vissimPath'])
-      print("      Output folder     : " + vtVars['outputPath'])            
-      if os.path.isfile(vtVars['elastixBinPath'].strip()): 
+      print("      Output folder     : " + vtVars['outputPath'])
+      if os.path.isfile(vtVars['elastixBinPath'].strip()):
           print("      elastix binaries are found in " + vtVars['elastixBinPath'] )
-      else:           
+      else:
           print("      elastix binaries are missing, please install SlicerElastix extension ... ")
           #TODO: download elastix binaries as additional option
           return -1
       #endif
-      othersWebLink =  ""      
+      othersWebLink =  ""
       if vsExtension ==0: # cochlea
-         # TODO: optimise this part to download only the missing files                 
-         print("      Cochlea Extension is selected")            
-      elif vsExtension ==1: # CervicalSpine             
-         print("      Spine Extension is selected")            
+         # TODO: optimise this part to download only the missing files
+         print("      Cochlea Extension is selected")
+      elif vsExtension ==1: # CervicalSpine
+         print("      Spine Extension is selected")
       else:
-         print("   Wrong extension ID")            
+         print("   Wrong extension ID")
          return -1
-      #endif 
+      #endif
       # check if model files exist
-      if  (os.path.exists(vtVars['modelPath'])) and (self.chkSHA256Sum(vtVars['modelPath'], self.OthersSHA256)): 
+      if  (os.path.exists(vtVars['modelPath'])) and (self.chkSHA256Sum(vtVars['modelPath'], self.OthersSHA256)):
           print("      Model folder is found..." )
           print("      Parameter file: "  + vtVars['parsPath'])
-          print("      Cropping Length: " + vtVars['croppingLength'] )             
+          print("      Cropping Length: " + vtVars['croppingLength'] )
       else:
           print("      Models or contents are wrong, trying to download ..." )
-          othersWebLink = vtVars['othersWebLink']      
-      #endif  
+          othersWebLink = vtVars['othersWebLink']
+      #endif
       if not othersWebLink=="":
          print("      Downloading VisSim Tools  ... ")
-         try:   
-                #Python2 and Python3 compitiblity  
+         try:
+                #Python2 and Python3 compitiblity
                 if sys.version_info[0] < 3:  #Python2
-                    import urllib as mylib                
+                    import urllib as mylib
                 else                           :  #Python3
-                    import urllib.request as mylib               
-                #endif                    
+                    import urllib.request as mylib
+                #endif
                 print("      Downloading VisSimTools others ...")
-                vissimZip = os.path.expanduser("~/VisSimToolsTmp.zip")      
-                uFile = mylib.urlretrieve(othersWebLink,vissimZip)   
+                vissimZip = os.path.expanduser("~/VisSimToolsTmp.zip")
+                uFile = mylib.urlretrieve(othersWebLink,vissimZip)
                 print ("     Extracting to user home ")
                 zip_ref = zipfile.ZipFile(vissimZip, 'r')
                 zip_ref.extractall(os.path.expanduser("~/"))
-                zip_ref.close()  
-                #remove the downloaded zip file     
-                os.remove(vissimZip)   
+                zip_ref.close()
+                #remove the downloaded zip file
+                os.remove(vissimZip)
                 print ("    done! ")
          except Exception as e:
                 print("      Error: can not download and extract VisSimTools ...")
-                print(e)   
+                print(e)
                 return -1
-       #end try-except        
-  #enddef  
+       #end try-except
+  #enddef
 
   def chkSHA256Sum(self, folderPath, sha256Sum):
       sha256_hash = hashlib.sha256()
@@ -219,30 +219,30 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
                # Read file in as little chunks
                buf = f1.read(4096)
                if not buf : break
-               #Python2 and Python3 compitiblity  
+               #Python2 and Python3 compitiblity
                if sys.version_info[0] < 3:  #Python2
                   sha256_hash.update(hashlib.sha256(buf).hexdigest())
                else                           :  #Python3
                   sha256_hash.update(hashlib.sha256(buf).digest())
-               #endif                    
+               #endif
             #endwhile
             f1.close()
         #endfor names
-      #endforroot      
+      #endforroot
       sha256computedCheckSum = sha256_hash.hexdigest()
-      updatedModel = False 
+      updatedModel = False
       print("      sha256computedCheckSum: " +sha256computedCheckSum)
       if sha256computedCheckSum == sha256Sum:
          updatedModel = True
-      #endif 
-      return updatedModel 
+      #endif
+      return updatedModel
   #enddef
 
   # string to boolean converter
   def s2b(self,s):
         return s.lower() in ("yes", "true", "t", "1")
   #enddef
-  
+
         inputPointT = self.vsc.v2t(inputPoint) # "["+str(inputPoint[0])+","+str(inputPoint[1])+","+str(inputPoint[2])+"]"
 
   #convert a vector to text
@@ -258,19 +258,19 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       t = t.split(",")
       for i in range(3):
           vector[i] =float(t[i])
-      return vector 
+      return vector
   #enddef
 
 #------------------------------------------------------
-#                  IJK to RAS  
+#                  IJK to RAS
 #------------------------------------------------------
-# This function convert an IJK point to RAS point 
+# This function convert an IJK point to RAS point
 #  input:  a point vector and volume node
-#  output: a point vector                     
+#  output: a point vector
   def ptIJK2RAS(self,ptIJK,inputImg): # imgPath or imgNode are supported
-        #TODO: add option for printing                   
-        # create a IJK2RAs transformation matrix 
-        inputImgNode =inputImg 
+        #TODO: add option for printing
+        # create a IJK2RAs transformation matrix
+        inputImgNode =inputImg
         if (isinstance(inputImg, str)):
             [success, inputImgNode] = slicer.util.loadVolume( inputImg, returnNode=True)
         #endif
@@ -279,100 +279,100 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
         ptRAS=np.zeros((len(ptIJK),3))
         ijk= ptIJK
         # create a 4 elements array to get the converted values
-        ijkv=[ijk[0],ijk[1],ijk[2],1]             
+        ijkv=[ijk[0],ijk[1],ijk[2],1]
         rasPt=ijk2rasM.MultiplyDoublePoint(ijkv)
         ptRAS=rasPt[0:3]
         if (isinstance(inputImg, str)):
            slicer.mrmlScene.RemoveNode(inputImgNode )
         #endif
 
-        return  ptRAS       
-   
+        return  ptRAS
+
 
 
 #------------------------------------------------------
-#                 RAS  to IJK 
-#------------------------------------------------------   
-# This function convert RAS ro an IJK point 
+#                 RAS  to IJK
+#------------------------------------------------------
+# This function convert RAS ro an IJK point
 #  input:  a point vector and volume node
-#  output: a point vector                     
-  def ptRAS2IJK(self,ptRAS,inputImg,i):      
-      inputImgNode =inputImg 
+#  output: a point vector
+  def ptRAS2IJK(self,ptRAS,inputImg,i):
+      inputImgNode =inputImg
       if (isinstance(inputImg, str)):
             [success, inputImgNode] = slicer.util.loadVolume( inputImg, returnNode=True)
       #endif
 
-      # create a RAS2IJK transformation matrix 
+      # create a RAS2IJK transformation matrix
       ras2ijkM = vtk.vtkMatrix4x4()
-      inputImgNode.GetRASToIJKMatrix(ras2ijkM)       
+      inputImgNode.GetRASToIJKMatrix(ras2ijkM)
       ras=[0,0,0]
       #'vtkSlicerMarkupsModuleMRMLPython.vtkMRMLMarkupsFiducialNode'
       if not type(ptRAS) =='str':
-         #TODO: add option for printing       
+         #TODO: add option for printing
          if not i is None:
             print(i)
-            print(type(ptRAS)) 
+            print(type(ptRAS))
             ptRAS.GetNthFiducialPosition(i,ras)
          else:
-            ptRAS.GetNthFiducialPosition(0,ras)             
-         #endif       
+            ptRAS.GetNthFiducialPosition(0,ras)
+         #endif
       else:
-            ras=self.t2v(ptRAS) 
-      #endif              
+            ras=self.t2v(ptRAS)
+      #endif
       # create a 4 elements array to get the converted values
-      rasv=[ras[0],ras[1],ras[2],1]             
+      rasv=[ras[0],ras[1],ras[2],1]
       ptIJKf=np.zeros(3);
       ijkPt=ras2ijkM.MultiplyPoint(rasv)
       ptIJKf[0]=ijkPt[0];ptIJKf [1]=ijkPt[1];ptIJKf [2]=ijkPt[2];
       ptIJK = ptIJKf.astype(np.int64)
       #print("RAS= " + str(ras)+ "   IJK= " + str(ptIJK))
-      return  ptIJK       
-    
-    
+      return  ptIJK
+
+
   #------------------------------------------------------
   #         image2points
   #------------------------------------------------------
   # This function converted a binary image to fiducials points
   # it is used for computing the length of the scala tympani
-  # as skelton methods don't work. 
+  # as skelton methods don't work.
   # Todo: redesign to be used externally
   #        we need to input a volume node only
-  def image2points(self,inputImgNode):          
-        print("====================================================")            
-        print("=                Image to Points                  =")      
-        print("====================================================") 
-        # clone the input image       
+  def image2points(self,inputImgNode):
+        print("====================================================")
+        print("=                Image to Points                  =")
+        print("====================================================")
+        # clone the input image
         nimg = sitkUtils.PullVolumeFromSlicer(inputImgNode.GetID())
         sz= inputImgNode.GetImageData().GetDimensions()
         tmpImgArray = slicer.util.array(inputImgNode.GetID())
         nimgMax = tmpImgArray.max()
         nimgMin = tmpImgArray.min()
-          
+
         b= list(zip( *np.where(tmpImgArray > (nimgMax/2 ) ) ))
         NoPts = len(b)
-        ptsIJK   =np.zeros((NoPts,4))        
-        ptsIJKtmp=np.zeros((NoPts,4))        
-        print("Number of points imported: " + str(NoPts))                  
+        ptsIJK   =np.zeros((NoPts,4))
+        ptsIJKtmp=np.zeros((NoPts,4))
+        print("Number of points imported: " + str(NoPts))
         for j in range (0,NoPts):
-               x= b[j][2] ; y= b[j][1] ; z= b[j][0]            
+               x= b[j][2] ; y= b[j][1] ; z= b[j][0]
                ptsIJK[j][0:3] =[ x ,y, z ]
                ptsIJKtmp[j][0:3]   =[ x ,y, z ]
-               ptsIJKtmp[j][3]     = tmpImgArray[z][y][x]      
-        #end for 
-                
-        ptsIJKtmp=  sorted(ptsIJKtmp, key = lambda t: t[-1])     
+               ptsIJKtmp[j][3]     = tmpImgArray[z][y][x]
+        #end for
+
+        ptsIJKtmp=  sorted(ptsIJKtmp, key = lambda t: t[-1])
 
         self.markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
         self.markupsNode.CreateDefaultDisplayNodes()
         self.markupsNode.SetName("P")
-        ptsRAS   =np.zeros((NoPts,3))        
+        ptsRAS   =np.zeros((NoPts,3))
         for j in range (0,NoPts):
-           ptsIJK[j][0:3] = ptsIJKtmp[j][0:3] 
-           ptsRAS[j]=  self.ptIJK2RAS(ptsIJK[j],inputImgNode)           
+           ptsIJK[j][0:3] = ptsIJKtmp[j][0:3]
+           ptsRAS[j]=  self.ptIJK2RAS(ptsIJK[j],inputImgNode)
            x = ptsRAS[j][0]; y = ptsRAS[j][1] ; z = ptsRAS[j][2]
            self.markupsNode.AddFiducial(x,y,z)
-        #endfor        
-                
+        #endfor
+
         # get the file name at the first of the plugin
         # this keeps the fiducials with short name
         #self.markupsNode.SetName(self.inputFnm + "StPts")
@@ -383,35 +383,35 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
 
 
   #-----------------------------------------------------------------------------------
-  #                       Cropping Process  
+  #                       Cropping Process
   #--------------------------------------------------------------------------------------------
-  # Using the location as a center point, we cropp around it using the defined cropLength 
+  # Using the location as a center point, we cropp around it using the defined cropLength
   # point must be a string in IJK format e.g. "[190,214,92]"
-  # this is useful to call the function from console with some arguments 
+  # this is useful to call the function from console with some arguments
   def runCropping(self, inputVolume, pointT,croppingLengthT, samplingLengthT, hrChkT,  vtIDt):
 
         print("================= Begin cropping  ... =====================")
-        # Create a temporary node as workaround for bad path or filename 
+        # Create a temporary node as workaround for bad path or filename
         #TODO: create a temp folder and remove temp node before display
         print(" location: " + pointT + "   cropping length: " + str(croppingLengthT) )
-        nodeName    = inputVolume.GetName() +"_Crop" 
-        nodeNameIso = inputVolume.GetName() +"_CropIso"        
-        inputCropPath = self.vtVars['vissimPath']+","+nodeName +".nrrd"                                 
-        inputCropPath = os.path.join(*inputCropPath.split(","))     
-        inputCropIsoPath = self.vtVars['vissimPath']+","+nodeNameIso +".nrrd"                               
-        inputCropIsoPath = os.path.join(*inputCropIsoPath.split(","))     
+        nodeName    = inputVolume.GetName() +"_Crop"
+        nodeNameIso = inputVolume.GetName() +"_CropIso"
+        inputCropPath = self.vtVars['vissimPath']+","+nodeName +".nrrd"
+        inputCropPath = os.path.join(*inputCropPath.split(","))
+        inputCropIsoPath = self.vtVars['vissimPath']+","+nodeNameIso +".nrrd"
+        inputCropIsoPath = os.path.join(*inputCropIsoPath.split(","))
 
         #for Spine
         if not vtIDt == 0:
            print("Vertebra "+vtIDt+ " location: " + pointT + "   cropping length: " + str(croppingLengthT) )
            nodeName    = inputVolume.GetName() +"_C" + vtIDt
-           nodeNameIso = inputVolume.GetName() +"_C" + vtIDt +"_iso"        
-           inputCropPath = self.vtVars['vissimPath']+","+nodeName  +".nrrd"                                        
-           inputCropPath = os.path.join(*inputCropPath.split(","))     
+           nodeNameIso = inputVolume.GetName() +"_C" + vtIDt +"_iso"
+           inputCropPath = self.vtVars['vissimPath']+","+nodeName  +".nrrd"
+           inputCropPath = os.path.join(*inputCropPath.split(","))
            inputCropIsoPath = self.vtVars['vissimPath']+","+nodeNameIso  +".nrrd"
-           inputCropIsoPath = os.path.join(*inputCropIsoPath.split(","))     
+           inputCropIsoPath = os.path.join(*inputCropIsoPath.split(","))
         #endif
-        
+
         croppingLength =   self.t2v(croppingLengthT)
         samplingLength =   self.t2v(samplingLengthT)
         hrChk          =   self.s2b(hrChkT)
@@ -424,14 +424,14 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
                 slicer.mrmlScene.RemoveNode(f )
             #endif
         #endfor
-        # resampling spacing  
+        # resampling spacing
         self.RSx= samplingLength[0] ; self.RSy=samplingLength[1];     self.RSz= samplingLength[2]
 
-        #Get input image information 
+        #Get input image information
         spacing = inputVolume.GetSpacing()
         imgData = inputVolume.GetImageData()
         dimensions = imgData.GetDimensions()
-        
+
         # compute cropping bounds from image information and cropping parameters
         croppingBounds = [[0,0,0],[0,0,0]];   size = [0,0,0];    lower = [0,0,0] ;     upper = [0,0,0]
         for i in range(0,3):
@@ -441,11 +441,11 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
             # Check if calculated boundaries exceed image dimensions
             if lower[i] < 0:
                     lower[i] = 0
-            #endif        
+            #endif
             if upper[i] > dimensions[i]:
                    upper[i] = int(dimensions[i])
             #endif
-        #endfor   
+        #endfor
         croppingBounds = [lower,upper]
         # Call SimpleITK CropImageFilter
         print("Cropping with " + str(croppingBounds[0]) + " and " + str(croppingBounds[1]) + ".")
@@ -453,21 +453,21 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
 
         inputImage = sitkUtils.PullVolumeFromSlicer(inputVolume.GetID())
         cropper = sitkUtils.sitk.CropImageFilter()
-        croppedImage = cropper.Execute(inputImage, croppingBounds[0], croppingBounds[1])                  
-        # Make a node with cropped image 
+        croppedImage = cropper.Execute(inputImage, croppingBounds[0], croppingBounds[1])
+        # Make a node with cropped image
         sitkUtils.PushVolumeToSlicer(croppedImage, None, nodeName , 'vtkMRMLScalarVolumeNode' )
         crNodes = slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode")
         for f in crNodes:
             if nodeName in f.GetName():
-                 f.SetName(nodeName) 
-                 break         
+                 f.SetName(nodeName)
+                 break
             #endif
-        #endfor  
+        #endfor
         croppedNode = slicer.util.getNode(nodeName)
         print("cropped:     "+inputCropPath)
         slicer.util.saveNode( croppedNode, inputCropPath)
         #-------------------------------------------------------
-        # Resampling: this produces better looking models  
+        # Resampling: this produces better looking models
         #-------------------------------------------------------
         #TODO: separate this in  a new function
         if hrChk:
@@ -479,15 +479,15 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
                #endif
            #endfor
            #Run slicer cli module: resample scalar volume
-           #inputCropIsoPath = os.path.splitext(inputVolume.GetStorageNode().GetFileName())[0] +"_C"+str(vtID) +"_crop_iso.nrrd"  
+           #inputCropIsoPath = os.path.splitext(inputVolume.GetStorageNode().GetFileName())[0] +"_C"+str(vtID) +"_crop_iso.nrrd"
            print("iso cropped: "+inputCropIsoPath)
            resampleSpacing = " ["+ str(self.RSx) + "," + str(self.RSy) + "," + str(self.RSz) + "] "
            SlicerBinPath=""
            ResampleBinPath=""
            ## this produces error in windows
            #resamplingCommand = slicer.modules.resamplescalarvolume.path
-           #os.system(resamplingCommand)                
-           #TODO: Get Slicer PATH			  
+           #os.system(resamplingCommand)
+           #TODO: Get Slicer PATH
            SlicerPath      =  os.path.abspath(os.path.join(os.path.abspath(os.path.join(os.sys.executable, os.pardir)), os.pardir))
            SlicerBinPath   =  os.path.join(SlicerPath,"Slicer")
            ResampleBinPath =  os.path.join(SlicerPath,"lib","Slicer-4.11" , "cli-modules","ResampleScalarVolume" )
@@ -499,10 +499,10 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
                resamplingCommand = ResampleBinPath + ".exe"
            #endtry
            print(resamplingCommand)
-           si = None 
-           currentOS = sys.platform           
-           cmdPars = " -i linear -s "+ resampleSpacing + inputCropPath +" "+inputCropIsoPath  
-           Cmd = resamplingCommand  + cmdPars		   
+           si = None
+           currentOS = sys.platform
+           cmdPars = " -i linear -s "+ resampleSpacing + inputCropPath +" "+inputCropIsoPath
+           Cmd = resamplingCommand  + cmdPars
            if sys.platform == 'win32':
               #note: in windows, no need to use --launch
               SlicerBinPath = SlicerBinPath +".exe"
@@ -517,36 +517,36 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
               print(currentOS)
               print("Executing ... "+Cmd)
               cRs = subprocess.call(Cmd , shell = (sys.platform == currentOS) , startupinfo=si )
-           #endif              
+           #endif
 
-           
+
            #inputCropPath = inputCropIsoPath
            print(" Cropping and resampling are done !!! ")
         #endif
 
         #inputCropPath    = inputCropPath.strip("'")
         print(" Cropped image is saved in : [%s]" % inputCropPath)
-        print(" Cropping is done !!! ") 
+        print(" Cropping is done !!! ")
         # so we can remove these files later
         return inputCropPath
-  #enddef                
+  #enddef
   #--------------------------------------------------------------------------------------------
   #                        run elastix
-  #--------------------------------------------------------------------------------------------      
+  #--------------------------------------------------------------------------------------------
   def runElastix(self, elastixBinPath, fixed, moving, output, parameters, verbose, line):
       print ("************  Compute the Transform **********************")
       currentOS = sys.platform
       print(currentOS)
-      Cmd = elastixBinPath + ' -f ' + fixed + ' -m ' +  moving  + ' -out ' +  output + ' -p ' + parameters 
+      Cmd = elastixBinPath + ' -f ' + fixed + ' -m ' +  moving  + ' -out ' +  output + ' -p ' + parameters
       errStr="No error!"
       if currentOS in ["win32","msys","cygwin"]:
-          print(" elastix is running in Windows :( !!!") 
+          print(" elastix is running in Windows :( !!!")
           print(Cmd)
           si = subprocess.STARTUPINFO()
           si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
           cTI = subprocess.call(Cmd , shell = (sys.platform == currentOS) , startupinfo=si )
       elif currentOS in ["linux","linux2"]:
-          print(" elastix is running in Linux :) !!!") 
+          print(" elastix is running in Linux :) !!!")
           CmdList = Cmd.split()
           print(CmdList)
           cTI=  subprocess.Popen(CmdList, env=self.elastixEnv,  stdout=subprocess.PIPE, universal_newlines=True)
@@ -554,43 +554,43 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
           out, err = cTI.communicate()
           cTI=int(not err==None)
       elif currentOS in ["darwin","os2","os2emx"]:
-          print(" elastix is running in Mac :( !!!") 
+          print(" elastix is running in Mac :( !!!")
           CmdList = Cmd.split()
           print(CmdList)
           cTI=  subprocess.Popen(CmdList, env=self.elastixEnv,  stdout=subprocess.PIPE, universal_newlines=True)
           cTI.wait()
           out, err = cTI.communicate()
-          cTI=int(not err==None)          
+          cTI=int(not err==None)
       else:
-            print(" elastix is running in Unknown system :( !!!")           
+            print(" elastix is running in Unknown system :( !!!")
             cTI=1
             errStr="elastix error at line"+ line +", check the log files"
       #endif
       print(cTI)
-      #time.sleep(5)      
+      #time.sleep(5)
       self.chkElxER(cTI,errStr) # Check if errors happen during elastix execution
-      
+
       return cTI
   #enddef
 
   #--------------------------------------------------------------------------------------------
   #                        run transformix
-  #--------------------------------------------------------------------------------------------      
+  #--------------------------------------------------------------------------------------------
   def runTransformix(self,transformixBinPath, img, output, parameters, verbose, line):
       print ("************  Apply transform **********************")
       currentOS = sys.platform
-      Cmd = transformixBinPath + ' -tp ' + parameters + ' -in ' +  img  +' -out ' +   output +' -def '+ ' all '              
+      Cmd = transformixBinPath + ' -tp ' + parameters + ' -in ' +  img  +' -out ' +   output +' -def '+ ' all '
       #if subprocess.mswindows:
       errStr="No error!"
-#      if hasattr(subprocess, 'mswindows'):          
+#      if hasattr(subprocess, 'mswindows'):
       if currentOS in ["win32","msys","cygwin"]:
-         print(" transformix is running in Windows :( !!!") 
-         print(Cmd)         
+         print(" transformix is running in Windows :( !!!")
+         print(Cmd)
          si = subprocess.STARTUPINFO()
          si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
          cTS = subprocess.call(Cmd , shell = (sys.platform == currentOS) , startupinfo=si )
       elif currentOS in ["linux","linux2"]:
-          print(" transformix is running in Linux :) !!!") 
+          print(" transformix is running in Linux :) !!!")
           CmdList = Cmd.split()
           print(CmdList)
           cTS=  subprocess.Popen(CmdList, env=self.elastixEnv,  stdout=subprocess.PIPE, universal_newlines=True)
@@ -598,7 +598,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
           out, err = cTS.communicate()
           cTS=int(not err==None)
       elif currentOS in ["darwin","os2","os2emx"]:
-          print(" transformix is running in Mac :( !!!") 
+          print(" transformix is running in Mac :( !!!")
           CmdList = Cmd.split()
           print(CmdList)
           cTS=  subprocess.Popen(CmdList, env=self.elastixEnv,  stdout=subprocess.PIPE, universal_newlines=True)
@@ -606,7 +606,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
           out, err = cTS.communicate()
           cTS=int(not err==None)
       else:
-            print(" elastix is running in Unknown system :( !!!")           
+            print(" elastix is running in Unknown system :( !!!")
             cTS=1
             errStr="transformix error at line"+ line +", check the log files"
       #endif
@@ -614,7 +614,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       self.chkElxER(cTS,errStr) # Check if errors happen during elastix execution
       return cTS
   #enddef
-        
+
   #--------------------------------------------------------------------------------------------
   #                       Check Elastix error
   #--------------------------------------------------------------------------------------------
@@ -622,18 +622,18 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
   def chkElxER(self,c, s):
         if c>0:
            #qt.QMessageBox.critical(slicer.util.mainWindow(),'segmentation', s)
-           print(s)  
+           print(s)
            return False
-        else: 
+        else:
             print("done !!!")
         #endif
- #enddef             
-            
-    
+ #enddef
+
+
   def openResultsFolder(self):
       if not hasattr(self, 'vtVars'):
          self.setGlobalVariables(1)
-      #endif 		 
+      #endif
       currentOS = sys.platform
       print(currentOS)
       if currentOS in ["win32","msys","cygwin"]:
@@ -643,11 +643,11 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       elif currentOS in ["darwin","os2","os2emx"]:
          cmd = os.system('open ' + self.vtVars['outputPath'])
       else:
-         print("uknown system")   
+         print("uknown system")
       #endif
-  #enddef  
+  #enddef
 
-  # segmenteditor effect on the resulted segmentations 
+  # segmenteditor effect on the resulted segmentations
   # this function is called by functions like doSmoothing and doMargining
   def getSegmentationEditor(self,segNode,masterNode):
             # Create segment editor to get access to effects
@@ -659,11 +659,11 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
            segmentEditorWidget.setMasterVolumeNode(masterNode)
            return segmentEditorWidget, segmentEditorNode
 
-  # smoothing segmentation effect    
-  #TODO: add more options   
-  def runSmoothing(self,segNode,masterNode,KernelSizeMm):       
+  # smoothing segmentation effect
+  #TODO: add more options
+  def runSmoothing(self,segNode,masterNode,KernelSizeMm):
            # Smoothing
-           [segEditorW,segEditorN]= self.getSegmentationEditor(segNode,masterNode)               
+           [segEditorW,segEditorN]= self.getSegmentationEditor(segNode,masterNode)
            for i in range (0,segNode.GetSegmentation().GetNumberOfSegments()):
                segmentID = segNode.GetSegmentation().GetNthSegmentID(i)
                segEditorW.setActiveEffectByName("Smoothing")
@@ -679,22 +679,22 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
   #enddef
 
   # Margin segmentation effect
-  # MarginSizeMm>0 Grow, else Shrink          
+  # MarginSizeMm>0 Grow, else Shrink
   def runMargining(self,segNode,masterNode,MarginSizeMm):
            #Dilation and Eroding
-           [segEditorW,segEditorN]= self.getSegmentationEditor(segNode,masterNode)               
+           [segEditorW,segEditorN]= self.getSegmentationEditor(segNode,masterNode)
            for i in range (0,segNode.GetSegmentation().GetNumberOfSegments()):
                segmentID = segNode.GetSegmentation().GetNthSegmentID(i)
                segEditorW.setActiveEffectByName("Margin")
                segEditorW.setCurrentSegmentID(segmentID)
                effect = segEditorW.activeEffect()
-               effect.setParameter("MarginSizeMm", MarginSizeMm) 
+               effect.setParameter("MarginSizeMm", MarginSizeMm)
                effect.self().onApply()
            #endfor
            # Clean up
            segEditorW = None
            slicer.mrmlScene.RemoveNode(segEditorN)
-  #enddef  
+  #enddef
 
   def removeOtputsFolderContents(self):
       try:
@@ -703,26 +703,26 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
               if os.path.isfile(filePath):
                  os.remove(filePath)
              #endif
-          #endfor                    
+          #endfor
       except Exception as e:
             print("nothing to delete ...")
             print(e)
-       #endtry 
-  #enddefr 
-                 
+       #endtry
+  #enddefr
+
   def removeTmpsFiles(self):
-      #remove old files 
+      #remove old files
       outputPath = self.vtVars['outputPath']
       print("removing temp output files!")
       fds=[]
       outoutputFolders = os.listdir(outputPath)
-      for fd in outoutputFolders:        
+      for fd in outoutputFolders:
           if os.path.isdir(os.path.join(outputPath,fd)):
-             fds.append(fd)   
+             fds.append(fd)
           #endif
-      #endfor 
-      fds.append(".")   
-      for fd in fds:         
+      #endfor
+      fds.append(".")
+      for fd in fds:
           print(os.path.join(outputPath,fd) )
           resfiles = os.listdir(os.path.join(outputPath,fd) )
           for fnm in resfiles:
@@ -738,8 +738,8 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
           #endfor fnm
       #endfor fd
       vissimPath = self.vtVars['vissimPath']
-      cropfiles = os.listdir(vissimPath) 
-      try:  
+      cropfiles = os.listdir(vissimPath)
+      try:
          for fnm in cropfiles:
              if "Crop" in fnm:
                  os.remove(os.path.join(vissimPath, fnm))
@@ -750,33 +750,33 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
          #endfor
       except Exception as e:
              print(" Error: can not remove " + fnm)
-             print(e)   
-      #endtry  
-      print("removing temp nodes ...!") 
+             print(e)
+      #endtry
+      print("removing temp nodes ...!")
       nodes = slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode')
       for f in nodes:
           if "_Crop"  in f.GetName(): slicer.mrmlScene.RemoveNode(f)
       nodes = slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode')
-      for f in nodes:         
-          if "Location" in f.GetName(): f.GetDisplayNode().SetVisibility(False) 
-      #endfor      
-      ##using dictionary doesn ot work: 
+      for f in nodes:
+          if "Location" in f.GetName(): f.GetDisplayNode().SetVisibility(False)
+      #endfor
+      ##using dictionary doesn ot work:
       ##remove temp nodes
       #nodes = slicer.util.getNodes().keys()
-      #for f in nodes:         
-      #    if ("_Crop"    in f): slicer.mrmlScene.RemoveNode(slicer.util.getNodes()[f]); 
+      #for f in nodes:
+      #    if ("_Crop"    in f): slicer.mrmlScene.RemoveNode(slicer.util.getNodes()[f]);
       #    #if ("Location" in f): slicer.mrmlScene.RemoveNode(slicer.util.getNodes()[f]);
       #    if ("Location" in f): slicer.util.getNodes()[f].GetDisplayNode().SetVisibility(False);
       #    #endif
       # #endfor
-  #enddef  
+  #enddef
 
   def rmvSlicerNode(self,node):
     slicer.mrmlScene.RemoveNode(node)
     slicer.mrmlScene.RemoveNode(node.GetDisplayNode())
     slicer.mrmlScene.RemoveNode(node.GetStorageNode())
   #enddef
-  # this can be used only if extension is running from GUI  
+  # this can be used only if extension is running from GUI
   def msgBox(self,txt):
       #msg = qt.QMessageBox()
       #msg.setIcon(qt.QMessageBox.Information)
@@ -789,7 +789,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
 
   def setItemChk(self,itemT, itemChk, itemName, nodes,):
       self.vtVars[itemT] = str(itemChk)
-      # Set unvisible 
+      # Set unvisible
       for f in nodes:
           if (itemName in f.GetName() ):
              f.GetDisplayNode().SetVisibility(self.s2b(self.vtVars[itemT]))
@@ -797,24 +797,24 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
             #break
           #endif
       #endfor
-      if (itemName =="cochleaSide" ):  
+      if (itemName =="cochleaSide" ):
           if itemChk:
-             self.vtVars[itemT] = "R"  
+             self.vtVars[itemT] = "R"
           else:
              self.vtVars[itemT] = "L"
           #endif
-          #print("side selected is " + self.vtVars[itemT]) 
+          #print("side selected is " + self.vtVars[itemT])
       #endif
 
    #enddef
-  
+
   def setVtID(self,idx,inputVolumeNode , inputFiducialNode):
       self.vtVars['vtID']=str(idx)
       print(self.vtVars['vtID']+ " is selected")
       self.inputVolumeNode = inputVolumeNode
-      self.inputFiducialNode = inputFiducialNode 
-      #remove old points 
-        
+      self.inputFiducialNode = inputFiducialNode
+      #remove old points
+
       # Check if a markup node exists
       newNode = True
       print(self.inputVolumeNode.GetName()+"_vtLocations")
@@ -822,42 +822,42 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       nodes = slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode')
       for f in nodes:
           if ((f.GetName() == self.inputVolumeNode.GetName()+"_vtLocations") ):
-             #replace  current 
+             #replace  current
              print("inputFiducialNode exist")
-             self.inputFiducialNode = f  
+             self.inputFiducialNode = f
              newNode= False
             #endif
-      #endfor      
+      #endfor
       if not (self.inputFiducialNode is None):
          ls = slicer.modules.markups.logic()
          ls.SetActiveListID(self.inputFiducialNode)
          print(ls.GetActiveListID())
-         noPts = self.inputFiducialNode.GetNumberOfFiducials() 
+         noPts = self.inputFiducialNode.GetNumberOfFiducials()
          newFid= True
          for j in range (0, noPts):
              if self.inputFiducialNode.GetNthFiducialLabel(j)==("C"+self.vtVars['vtID']) :
-                newFid= False 
+                newFid= False
                 print("C"+self.vtVars['vtID'] +" exist, removing old point at: " +str(j))
                 #get the new location
-                self.inputFiducialNode.RemoveMarkup(j)      
+                self.inputFiducialNode.RemoveMarkup(j)
              #endif
          #endfor
       else:
          print("inputFiducialNode does not exist")
-      #endif        
+      #endif
   #enddef
-      
+
   # check if vertebra location is available
   def setVtIDfromEdt(self,point,vtID):
         # no external call
         #print("no external call, point= " + point)
         self.vtVars['vtID'] = str(vtID)
         isExternalCall = False
-        print("point changed,  " + str(vtID) + " is selected")      
-        #TODO: add option to use point from text for cropping   
-        return isExternalCall     
+        print("point changed,  " + str(vtID) + " is selected")
+        #TODO: add option to use point from text for cropping
+        return isExternalCall
   #enddef
-      
+
   #this part need to be optimized
   # reg =0: no registration, 1: fixed image, 2: moving image
   def locateItem(self, inputVolumeNode, inputPointEdt, reg, vtID):
@@ -872,10 +872,10 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
          regType="M"
       else:
          regType=""
-      #endif 
+      #endif
       if not hasattr(self, 'vtVars'):
          self.setGlobalVariables(int(not (vtID==0)) )
-      #end             
+      #end
       self.inputVolumeNode   = inputVolumeNode
       self.inputPointEdt =inputPointEdt
       self.vtVars['vtID']= str(vtID)
@@ -904,20 +904,20 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       #endfor
 
       if vtID==0: #Cochlea:
-         print(" ..... getting Cochlea location in the input image")  
-         self.FidLabel =  regType+"_CochleaLocation"       
+         print(" ..... getting Cochlea location in the input image")
+         self.FidLabel =  regType+"_CochleaLocation"
       else: #cervical spine
          # redefine to be used in the logic class.
-         print(" ..... getting vertebra location in the input image")  
+         print(" ..... getting vertebra location in the input image")
          self.FidLabel= regType+"_vtLocations"
-      #endif        
+      #endif
       # Check if a markup node exists
       newNode = True
       nodes = slicer.util.getNodesByClass('vtkMRMLMarkupsFiducialNode')
       for f in nodes:
              if ((f.GetName() == inputVolumeNode.GetName()+self.FidLabel ) ):
-                  #replace  current 
-                  self.inputFiducialNodes[reg] = f  
+                  #replace  current
+                  self.inputFiducialNodes[reg] = f
                   newNode= False
               #endif
       #endfor
@@ -926,10 +926,10 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
             self.inputFiducialNodes[reg] = slicer.vtkMRMLMarkupsFiducialNode()
             self.inputFiducialNodes[reg].SetName(inputVolumeNode.GetName()+self.FidLabel)
             slicer.mrmlScene.AddNode(self.inputFiducialNodes[reg])
-      #endif     
-      self.inputFiducialNodes[reg].GetDisplayNode().SetVisibility(True);        
+      #endif
+      self.inputFiducialNodes[reg].GetDisplayNode().SetVisibility(True);
       self.inputFiducialNodes[reg].GetDisplayNode().SetTextScale(2)
-      self.inputFiducialNodes[reg].GetDisplayNode().SetSelectedColor(1,0,0)           
+      self.inputFiducialNodes[reg].GetDisplayNode().SetSelectedColor(1,0,0)
       # Start Fiducial Placement Mode in Slicer for one node only
       placeModePersistance = 0 # one node only
       slicer.modules.markups.logic().StartPlaceMode(placeModePersistance)
@@ -938,7 +938,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       self.addObs = self.inputFiducialNodes[reg].AddObserver(self.inputFiducialNodes[reg].PointAddedEvent,   self.onInputFiducialNodePointAddedEvent)
       self.modObs = self.inputFiducialNodes[reg].AddObserver(self.inputFiducialNodes[reg].PointModifiedEvent, self.onInputFiducialNodePointModifiedEvent)
       self.rmvObs = self.inputFiducialNodes[reg].AddObserver(self.inputFiducialNodes[reg].PointRemovedEvent, self.onInputFiducialNodePointRemovedEvent)
-      return  self.inputFiducialNodes[reg]   
+      return  self.inputFiducialNodes[reg]
   #enddef
 
   #--------------------------------------------------------------------------------------------
@@ -949,8 +949,8 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       print("Fiducial adding event!")
       #remove previous observer
       caller.RemoveObserver(self.addObs)
-      noPts = caller.GetNumberOfFiducials() 
-      rasPt = [0,0,0] 
+      noPts = caller.GetNumberOfFiducials()
+      rasPt = [0,0,0]
       if self.vtVars['vtID']== "0":  #Cochlea
          caller.SetNthFiducialLabel(noPts-1, self.FidLabel)
          caller.GetNthFiducialPosition(noPts-1,rasPt)
@@ -958,28 +958,28 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
          caller.SetNthFiducialLabel(noPts-1, "C"+self.vtVars['vtID'])
          caller.GetNthFiducialPosition(noPts-1,rasPt)
       #self.inputPoint = self.vsc.ptRAS2IJK(caller, rasPt,self.inputVolumeNode,noPts-1)
-      self.inputPoint = self.ptRAS2IJK( caller,self.inputVolumeNode,noPts-1)       
+      self.inputPoint = self.ptRAS2IJK( caller,self.inputVolumeNode,noPts-1)
       self.inputPointEdt.setText(str(self.inputPoint))
-      print(" ..... location RAS: " + str(rasPt))  
+      print(" ..... location RAS: " + str(rasPt))
       print(" ..... location in the input image set to: " + str(self.inputPoint))
-  #enddef  
-  
+  #enddef
+
   #--------------------------------------------------------------------------------------------
   #    InputFiducialNode PointModifiedEvent
   #--------------------------------------------------------------------------------------------
   # The fiducial point saved in RAS, we need to convert to IJK
-  #  more info in our wiki 
+  #  more info in our wiki
   def onInputFiducialNodePointModifiedEvent(self, caller, event):
       #caller.RemoveObserver(self.modObs)
       # get the new IJK position and display it
-      rasPt = [0,0,0] 
+      rasPt = [0,0,0]
       i = caller.GetAttribute('Markups.MovingMarkupIndex')
       if not (i is None or i==''):
          i=int(i)
          caller.GetNthFiducialPosition(i,rasPt)
-         self.inputPoint = self.ptRAS2IJK(caller, self.inputVolumeNode, i)        
+         self.inputPoint = self.ptRAS2IJK(caller, self.inputVolumeNode, i)
          self.inputPointEdt.setText(str(self.inputPoint))
-      #endif   
+      #endif
   #enddef
 
   def onInputFiducialNodePointRemovedEvent(self, caller, event):
@@ -990,7 +990,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
   #endif
 
   #--------------------------------------------------------------------------------------------
-  #                        Calculate Segmentation Information    
+  #                        Calculate Segmentation Information
   #--------------------------------------------------------------------------------------------
   def getItemInfo(self, segNode, masterNode, tblNode, vtID):
         segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
@@ -1001,9 +1001,9 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
         segStatLogic.computeStatistics()
         if vtID == 0:  # Cochlea
            # compute the fiducial length
-           segStatLogic.exportToTable(tblNode)           
-           tblNode.SetCellText(0,2,self.vtVars['StLength'])           
-           tblNode.SetCellText(1,2,"0")   
+           segStatLogic.exportToTable(tblNode)
+           tblNode.SetCellText(0,2,self.vtVars['StLength'])
+           tblNode.SetCellText(1,2,"0")
         else           :  #Spine
            #  egt volume size of a vertebra
            if tblNode is None:
@@ -1016,7 +1016,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
 
               for i in range(5):
                  tblNode.AddColumn()
-              #endfor 
+              #endfor
               tblNode.GetTable().GetColumn(0).SetName("Vertebra")
               tblNode.GetTable().GetColumn(1).SetName("Volume mm3")
               tblNode.GetTable().GetColumn(2).SetName("CoM X")
@@ -1028,32 +1028,32 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
            #remove old row of this vertebra if exists
            for i in range (tblNode.GetNumberOfRows()):
                if "C"+str(vtID) == tblNode.GetCellText(i,0):
-                  print( "C"+str(vtID) + " table row exists, old values will be removed in row." + str(i)) 
-                  tblNode.RemoveRow(i)   
+                  print( "C"+str(vtID) + " table row exists, old values will be removed in row." + str(i))
+                  tblNode.RemoveRow(i)
                #endif
            #endfor
-           tblNode.AddEmptyRow() # empty row for current vertebra info    
+           tblNode.AddEmptyRow() # empty row for current vertebra info
 
            spTmpTblNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
            spTmpTblNode.SetName("tmpTable")
-           segStatLogic.exportToTable(spTmpTblNode)        
-           idx = tblNode.GetNumberOfRows()-1 # this should be the empty row we added 
+           segStatLogic.exportToTable(spTmpTblNode)
+           idx = tblNode.GetNumberOfRows()-1 # this should be the empty row we added
            print(" last row index: "+ str(idx))
-           tblNode.GetTable().SetRow(  idx  ,  spTmpTblNode.GetTable().GetRow(0)  ) 
-           tblNode.SetCellText(idx,2," ") 
-           tblNode.SetCellText(idx,3," ") 
-           tblNode.SetCellText(idx,4," ") 
+           tblNode.GetTable().SetRow(  idx  ,  spTmpTblNode.GetTable().GetRow(0)  )
+           tblNode.SetCellText(idx,2," ")
+           tblNode.SetCellText(idx,3," ")
+           tblNode.SetCellText(idx,4," ")
            slicer.mrmlScene.RemoveNode(spTmpTblNode )
 
-           # if this is C7 compute center of mass        
+           # if this is C7 compute center of mass
            if (vtID ==7) and (self.vtVars['vtMethodID']== "0"): # for testing
-              print("updating COM in table ..............")     
+              print("updating COM in table ..............")
               segID = segNode.GetSegmentation().GetSegmentIdBySegmentName("C"+str(vtID))
               modelNode = segNode.GetClosedSurfaceRepresentation(segID)
               com = vtk.vtkCenterOfMass(); com.SetInputData(modelNode);   com.Update()
               segNodeCoM = com.GetCenter()
-              tblNode.SetCellText(idx,2,str(segNodeCoM[0])) 
-              tblNode.SetCellText(idx,3,str(segNodeCoM[1])) 
+              tblNode.SetCellText(idx,2,str(segNodeCoM[0]))
+              tblNode.SetCellText(idx,3,str(segNodeCoM[1]))
               tblNode.SetCellText(idx,4,str(segNodeCoM[2]))
               self.vtVars['segNodeCoM']=str(segNodeCoM)
               #if  tblNode.GetCellText(tblNode.GetNumberOfRows(),0)=="":
@@ -1062,36 +1062,36 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
            #endif
         #endifelse
         # update table and set it the active table in slicer
-        print("updating table ..............") 
+        print("updating table ..............")
         tblNode.Modified()
         slicer.app.applicationLogic().GetSelectionNode().SetActiveTableID(tblNode.GetID())
         slicer.app.applicationLogic().PropagateTableSelection()
         return tblNode
   #enddef
-  
+
   #--------------------------------------------------------------------------------------------
   #                        Calculate length and volume of scalas
   #--------------------------------------------------------------------------------------------
-  # This function compute the distance between all the fiducials in a markupnode       
+  # This function compute the distance between all the fiducials in a markupnode
   def getFiducilsDistance(self,markupsNode,tblNode):
-        markupsDistance = 0 ; rasPt0 = [0,0,0] ; rasPt1 = [0,0,0] ; 
-        
+        markupsDistance = 0 ; rasPt0 = [0,0,0] ; rasPt1 = [0,0,0] ;
+
         for i in range(0, markupsNode.GetNumberOfFiducials()):
             markupsNode.GetNthFiducialPosition(i,rasPt1)
-            if (i>0) : 
+            if (i>0) :
                 markupsNode.GetNthFiducialPosition(i-1,rasPt0)
-                x0 =rasPt0[0]  ; y0= rasPt0[1]  ; z0=rasPt0[2]                 
-                x1 =rasPt1[0]  ; y1= rasPt1[1]  ; z1=rasPt1[2]                 
+                x0 =rasPt0[0]  ; y0= rasPt0[1]  ; z0=rasPt0[2]
+                x1 =rasPt1[0]  ; y1= rasPt1[1]  ; z1=rasPt1[2]
                 markupsDistance = markupsDistance +  math.sqrt( (x1-x0)**2 + (y1-y0)**2 + (z1-z0)**2 )
             #endif
-        #endfor    
+        #endfor
         self.vtVars['StLength'] = str(markupsDistance)
-        if not tblNode is None: 
+        if not tblNode is None:
            tblNode.SetCellText(0,2,self.vtVars['StLength'])
         #endif
-           
+
         return markupsDistance
-  #enddef  
+  #enddef
   def fitAllSlicesViews(self):
       sliceNodes = slicer.util.getNodes('vtkMRMLSliceNode*')
       layoutManager = slicer.app.layoutManager()
@@ -1109,7 +1109,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       print ("Disable enabled is " + str(disableColor))
       firstNode = slicer.util.getNode(slicer.app.layoutManager().sliceWidget(slicer.app.layoutManager().sliceViewNames()[0]).sliceLogic().GetSliceCompositeNode().GetForegroundVolumeID())
       secondNode = slicer.util.getNode(slicer.app.layoutManager().sliceWidget(slicer.app.layoutManager().sliceViewNames()[0]).sliceLogic().GetSliceCompositeNode().GetBackgroundVolumeID())
-      self.fuseTwoImages( firstNode, secondNode , not disableColor)            
+      self.fuseTwoImages( firstNode, secondNode , not disableColor)
   #enddef
 
   #fuse two images with two different colors
@@ -1122,8 +1122,8 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
          self.vtVars['nodeColorBG']          = slicer.modules.colors.logic().GetColorTableNodeID(1)  # gray color
       #endif
       #TODO: replace this with a loop or short code
-      for i in range(3):     
-          print(i) 
+      for i in range(3):
+          print(i)
           viewSliceCompositeNode = slicer.app.layoutManager().sliceWidget(slicer.app.layoutManager().sliceViewNames()[i]).sliceLogic().GetSliceCompositeNode()
           viewSliceCompositeNode.SetBackgroundVolumeID(firstNode.GetID())
           viewSliceCompositeNode.SetForegroundVolumeID(secondNode.GetID())
@@ -1131,7 +1131,7 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       #endfor
 
       # The layout is set to show only the default view.
-      slicer.app.layoutManager().setLayout(int(self.vtVars['dispViewID']))                             
+      slicer.app.layoutManager().setLayout(int(self.vtVars['dispViewID']))
       # The window level for each image is set to be the same value.
       firstNode.GetScalarVolumeDisplayNode().AutoWindowLevelOff()
       firstNode.GetScalarVolumeDisplayNode().SetWindowLevel(1000, 400)
@@ -1143,11 +1143,11 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
       secondNode.GetDisplayNode().SetAndObserveColorNodeID(self.vtVars['nodeColorBG']) # magenta color table
 
       # Fit slices to window
-      self.fitAllSlicesViews() 
+      self.fitAllSlicesViews()
   #enddef
 
   def dispSeg(self,inputVolumeNode, vtSegNode, view):
-        lm = slicer.app.layoutManager();   
+        lm = slicer.app.layoutManager();
         lm.setLayout(view)
         r_logic = lm.sliceWidget("Red").sliceLogic()
         r_cn = r_logic.GetSliceCompositeNode()
@@ -1162,22 +1162,22 @@ class VisSimCommonLogic(ScriptedLoadableModuleLogic):
         #center 3D view and zoom in 3 times
         v3DDWidget = lm.threeDWidget(0)
         v3DDWidgetV = v3DDWidget.threeDView()
-        v3DDWidgetV.resetFocalPoint() 
+        v3DDWidgetV.resetFocalPoint()
         v3DDWidgetV.zoomFactor =3
         v3DDWidgetV.zoomIn()
         v3DDWidgetV.zoomFactor =0.05 # back to default value
   #enddef
-    
-    
-    
+
+
+
 class VisSimCommonTest(ScriptedLoadableModuleLogic):
 
   def setUp(self):
-    slicer.mrmlScene.Clear(0)   
+    slicer.mrmlScene.Clear(0)
   #enddef
 
   def runTest(self):
     self.setUp()
     print(VisSimCommonLogic().tstSum(10,20))
   #enddef
-#enclass 
+#enclass

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,14 +16,14 @@
 <link rel="stylesheet" href="style.css">
 
 <title>Slicer Cochlea Documentation</title>
-   
+
 </head>
 <body>
 
 
 <div id="mainContainer">
 
-         <h2>	Slicer Cochlea Documentation   </h2>                  
+         <h2>	Slicer Cochlea Documentation   </h2>
 
 <p>The cochlea is a very important part of the inner ear. It is responsible for the transfer of audio signals to the brain. </p>
 
@@ -44,10 +44,10 @@
 <a style="font-family:Helvetica;" href="https://cdn.ymaws.com/www.acialliance.org/resource/resmgr/CI2018/CI2018_PPT/CI2018_DC_Podium_Abstracts.pdf" target="contents" > (link).</a>
 </li>
   <li>Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus and Roland Jacob, (2017): Automatic Cochlea Segmentation Using Diffusion Snakes. In: 15th Symposium on Cochlear Implants in Children, CI 2017, San Francisco, USA
-<a style="font-family:Helvetica;" href="https://cdn.ymaws.com/www.acialliance.org/resource/resmgr/ci2017/CI2017_PPT/CI2017_Podium_Abstracts.pdf"  target="contents" > (link). </a> 
+<a style="font-family:Helvetica;" href="https://cdn.ymaws.com/www.acialliance.org/resource/resmgr/ci2017/CI2017_PPT/CI2017_Podium_Abstracts.pdf"  target="contents" > (link). </a>
 </li>
-  <li>Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Friedrich Lisseck and Roland Jacob, (2017): ACIR: automatic cochlea image registration. In: Proceedings SPIE Medical Imaging 2017: Image Processing;. SPIE. Bd. 10133. S. 10133p1-10133p5 
-<a style="font-family:Helvetica;" href="http://spie.org/Publications/Proceedings/Paper/10.1117/12.2254396"  target="contents" > (link). </a> 
+  <li>Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Friedrich Lisseck and Roland Jacob, (2017): ACIR: automatic cochlea image registration. In: Proceedings SPIE Medical Imaging 2017: Image Processing;. SPIE. Bd. 10133. S. 10133p1-10133p5
+<a style="font-family:Helvetica;" href="http://spie.org/Publications/Proceedings/Paper/10.1117/12.2254396"  target="contents" > (link). </a>
 </li>
   <li>Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Friedrich Lissek, Roland Jacob(2016): Automatic Multimodal Registration and Fusion of 3D Human Cochlea Images. In: 14th International Conference on Cochlear Implants, Toronto, Canada. S. 511-514. <br/><br/></li>
 </ol>
@@ -79,16 +79,16 @@
 <p> 4. You may modify the length by clicking on the end-points in the 3D view then click on Update Length. This helps to correct errors or to get different mesuerments e.g. interior, center or exterior lengths.  </p>
        <img src="images/Seg05.png"  style="width:1200px;height:900px;" />
 <br><br><br>
- 
+
 <br><br><br>
 <p> <b>Resources: </b>
 <p>  <a href="https://www.youtube.com/watch?v=oRQ767ojS9o&index=2&list=PLW9iOMxMvikrSyerCLPJhTZnNUDBNpSYO&t=159s"  >Cochlea registration demo.</a>
 <p>  <a href="https://www.youtube.com/watch?v=A_mTcT3eT_c&index=2&list=PLW9iOMxMvikrSyerCLPJhTZnNUDBNpSYO"  >Cochlea segmentation demo.</a>
 <p>  <a href="https://mtixnat.uni-koblenz.de/downloads.html"  >Source-codes and datasets.</a>
- 
+
 </div>
 
-	 
+
 </body>
 
 </html>

--- a/link2Me.sh
+++ b/link2Me.sh
@@ -7,9 +7,9 @@ ghb=""
 #Cochlea
 ext="SlicerCochlea"
 mv $ewd1/$ext/$ewd2/CochleaReg.py $ewd1/$ext/$ewd2/CochleaReg.py.bk
-ln -s $PWD/CochleaReg/CochleaReg.py $ewd1/$ext/$ewd2/CochleaReg.py  
+ln -s $PWD/CochleaReg/CochleaReg.py $ewd1/$ext/$ewd2/CochleaReg.py
 mv $ewd1/$ext/$ewd2/CochleaSeg.py $ewd1/$ext/$ewd2/CochleaSeg.py.bk
-ln -s $PWD/CochleaSeg/CochleaSeg.py $ewd1/$ext/$ewd2/CochleaSeg.py  
+ln -s $PWD/CochleaSeg/CochleaSeg.py $ewd1/$ext/$ewd2/CochleaSeg.py
 mv $ewd1/$ext/$ewd2/VisSimCommon.py $ewd1/$ext/$ewd2/VisSimCommon.py.bk
 ln -s $PWD/VisSimCommon/VisSimCommon.py $ewd1/$ext/$ewd2/VisSimCommon.py
 


### PR DESCRIPTION
This PR trims all trailing whitespace.

I highly suggest turning on automatic trimming of trailing whitespace in your editor of choice (Visual Studio Code, Atom, NotePad++, VIM, etc).  It helps prevent diffs from having a ton of line changes that are simply changes to trailing spaces.

Here's an image of the setting in Visual Studio Code:
![trim-whitespace](https://user-images.githubusercontent.com/15837524/59977021-25038280-959a-11e9-9a6c-a92d886ef7b4.PNG)